### PR TITLE
[MOD] HomeScreen & HomeViewModel StateFlow

### DIFF
--- a/feature/home/src/main/java/com/eshc/goonersapp/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/eshc/goonersapp/feature/home/HomeScreen.kt
@@ -1,17 +1,22 @@
 package com.eshc.goonersapp.feature.home
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -22,6 +27,8 @@ import com.eshc.goonersapp.core.designsystem.theme.GnrTypography
 import com.eshc.goonersapp.feature.home.component.DashboardCard
 import com.eshc.goonersapp.feature.home.component.RecentlyMatchCard
 import com.eshc.goonersapp.feature.home.component.UpcomingMatchCard
+import com.eshc.goonersapp.feature.home.state.RecentlyResultUiState
+import com.eshc.goonersapp.feature.home.state.UpcomingMatchesUiState
 
 @Composable
 fun HomeRoute(
@@ -30,6 +37,9 @@ fun HomeRoute(
     viewModel: HomeViewModel = hiltViewModel(),
     onShowSnackbar : (String) -> Unit
 ) {
+    val upcomingMatchesUiState by viewModel.upcomingMatchesUiStateFlow.collectAsStateWithLifecycle()
+    val recentlyResultUiState by viewModel.recentlyResultUiStateFlow.collectAsStateWithLifecycle()
+
     Scaffold(
         topBar = {
             topBar()
@@ -40,7 +50,8 @@ fun HomeRoute(
     ) { padding ->
         HomeScreen(
             modifier = Modifier.padding(padding),
-            viewModel
+            upcomingMatchesUiState = upcomingMatchesUiState,
+            recentlyResultUiState = recentlyResultUiState
         )
     }
 }
@@ -48,11 +59,9 @@ fun HomeRoute(
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
-    viewModel: HomeViewModel
+    upcomingMatchesUiState: UpcomingMatchesUiState,
+    recentlyResultUiState: RecentlyResultUiState
 ) {
-    val upcomingMatches by viewModel.upcomingMatches.collectAsStateWithLifecycle()
-    val recentlyMatch by viewModel.recentlyMatch.collectAsStateWithLifecycle()
-
     LazyColumn(
         modifier = modifier,
         contentPadding = PaddingValues(top = 12.dp)
@@ -74,54 +83,136 @@ fun HomeScreen(
                 style = GnrTypography.subtitleMedium,
                 color = Color.Black,
             )
-            LazyRow(
-                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                items(
-                    items = upcomingMatches,
-                    key = { upcomingMatches -> upcomingMatches.id }
-                ) { matches ->
-                    UpcomingMatchCard(
-                        homeUrl = matches.homeTeamImageUrl,
-                        homeShortName = matches.homeTeamNickname,
-                        awayUrl = matches.awayTeamImageUrl,
-                        awayShortName = matches.awayTeamNickname,
-                        time = DateUtil.getYearAndMonthAndDateAndTimeString(matches.matchDate),
-                        location = if (matches.stadiumName == "null") "" else matches.stadiumName,
-                        competitionUrl = matches.leagueImageUrl,
-                        competitionName = "Premier League"
-                    )
+            when (upcomingMatchesUiState) {
+                is UpcomingMatchesUiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(131.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                is UpcomingMatchesUiState.Success -> {
+                    LazyRow(
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        items(
+                            items = upcomingMatchesUiState.data,
+                            key = { upcomingMatches -> upcomingMatches.id }
+                        ) { matches ->
+                            UpcomingMatchCard(
+                                homeUrl = matches.homeTeamImageUrl,
+                                homeShortName = matches.homeTeamNickname,
+                                awayUrl = matches.awayTeamImageUrl,
+                                awayShortName = matches.awayTeamNickname,
+                                time = DateUtil.getYearAndMonthAndDateAndTimeString(matches.matchDate),
+                                location = if (matches.stadiumName == "null") "" else matches.stadiumName,
+                                competitionUrl = matches.leagueImageUrl,
+                                competitionName = "Premier League"
+                            )
+                        }
+                    }
+                }
+                is UpcomingMatchesUiState.Failed -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(131.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Upcoming Matches cannot be loaded.",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = Color.LightGray,
+                        )
+                    }
+                }
+                is UpcomingMatchesUiState.Error -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(131.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Error! ${upcomingMatchesUiState.throwable}",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = Color.LightGray,
+                        )
+                    }
                 }
             }
         }
 
-        recentlyMatch?.let { match ->
-            item {
-                Text(
-                    modifier = Modifier.padding(start = 8.dp),
-                    text = "Recently Result",
-                    style = GnrTypography.subtitleMedium,
-                    color = Color.Black,
-                )
-                RecentlyMatchCard(
-                    competitionUrl = match.match.leagueImageUrl,
-                    competitionName = "Premier league",
-                    time = DateUtil.getYearAndMonthAndDateAndTimeString(match.match.matchDate),
-                    location = match.match.stadiumName,
-                    homeId = match.match.homeTeamId,
-                    homeUrl = match.match.homeTeamImageUrl,
-                    homeShortName = match.match.homeTeamNickname,
-                    homeScore = match.match.homeScore.toString(),
-                    awayId = match.match.awayTeamId,
-                    awayUrl = match.match.awayTeamImageUrl,
-                    awayShortName = match.match.awayTeamNickname,
-                    awayScore = match.match.awayScore.toString(),
-                    matchHistory = match.matchDetail
-                )
+        item {
+            Text(
+                modifier = Modifier.padding(start = 8.dp),
+                text = "Recently Result",
+                style = GnrTypography.subtitleMedium,
+                color = Color.Black,
+            )
+            when (recentlyResultUiState) {
+                is RecentlyResultUiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(273.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                is RecentlyResultUiState.Success -> {
+                    recentlyResultUiState.data?.let { match ->
+                        RecentlyMatchCard(
+                            competitionUrl = match.match.leagueImageUrl,
+                            competitionName = "Premier league",
+                            time = DateUtil.getYearAndMonthAndDateAndTimeString(match.match.matchDate),
+                            location = match.match.stadiumName,
+                            homeId = match.match.homeTeamId,
+                            homeUrl = match.match.homeTeamImageUrl,
+                            homeShortName = match.match.homeTeamNickname,
+                            homeScore = match.match.homeScore.toString(),
+                            awayId = match.match.awayTeamId,
+                            awayUrl = match.match.awayTeamImageUrl,
+                            awayShortName = match.match.awayTeamNickname,
+                            awayScore = match.match.awayScore.toString(),
+                            matchHistory = match.matchDetail
+                        )
+                    }
+                }
+                is RecentlyResultUiState.Failed -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(273.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Recently Result cannot be loaded.",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = Color.LightGray,
+                        )
+                    }
+                }
+                is RecentlyResultUiState.Error -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(273.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Error! ${recentlyResultUiState.throwable}",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = Color.LightGray,
+                        )
+                    }
+                }
             }
         }
-
     }
 }
-

--- a/feature/home/src/main/java/com/eshc/goonersapp/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/eshc/goonersapp/feature/home/HomeViewModel.kt
@@ -3,48 +3,50 @@ package com.eshc.goonersapp.feature.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.eshc.goonersapp.core.domain.model.DataResult
-import com.eshc.goonersapp.core.domain.model.match.Match
-import com.eshc.goonersapp.core.domain.model.match.MatchRecently
 import com.eshc.goonersapp.core.domain.usecase.match.GetRecentlyMatchUseCase
 import com.eshc.goonersapp.core.domain.usecase.match.GetUpcomingMatchesUseCase
+import com.eshc.goonersapp.feature.home.state.RecentlyResultUiState
+import com.eshc.goonersapp.feature.home.state.UpcomingMatchesUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val getUpcomingMatchesUseCase: GetUpcomingMatchesUseCase,
-    private val getRecentlyMatchUseCase: GetRecentlyMatchUseCase
+    getUpcomingMatchesUseCase: GetUpcomingMatchesUseCase,
+    getRecentlyMatchUseCase: GetRecentlyMatchUseCase
 ) : ViewModel() {
-    private val _upcomingMatches = MutableStateFlow<List<Match>>(emptyList())
-    val upcomingMatches : StateFlow<List<Match>> = _upcomingMatches.asStateFlow()
-
-    private val _recentlyMatch = MutableStateFlow<MatchRecently?>(null)
-    val recentlyMatch : StateFlow<MatchRecently?> = _recentlyMatch.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            getUpcomingMatchesUseCase()
-                .catch { /* TODO("Not yet implemented") */ }
-                .collect {
-                    when(it){
-                        is DataResult.Success -> _upcomingMatches.emit(it.data)
-                        is DataResult.Failure -> { /* TODO("Not yet implemented") */ }
-                    }
+    val upcomingMatchesUiStateFlow: StateFlow<UpcomingMatchesUiState> =
+        getUpcomingMatchesUseCase()
+            .catch { exception ->
+                UpcomingMatchesUiState.Error(exception.message)
+            }.map { result ->
+                when (result) {
+                    is DataResult.Success -> { UpcomingMatchesUiState.Success(result.data) }
+                    is DataResult.Failure -> { UpcomingMatchesUiState.Failed(result.message) }
                 }
+            }.stateIn(
+                scope = viewModelScope,
+                initialValue = UpcomingMatchesUiState.Loading,
+                started = SharingStarted.Eagerly
+            )
 
-            getRecentlyMatchUseCase()
-                .catch { /* TODO("Not yet implemented") */ }
-                .collect {
-                    when(it){
-                        is DataResult.Success ->  _recentlyMatch.emit(it.data)
-                        is DataResult.Failure -> { /* TODO("Not yet implemented") */ }
-                    }
+    val recentlyResultUiStateFlow: StateFlow<RecentlyResultUiState> =
+        getRecentlyMatchUseCase()
+            .catch { exception ->
+                RecentlyResultUiState.Error(exception.message)
+            }.map { result ->
+                when (result) {
+                    is DataResult.Success -> { RecentlyResultUiState.Success(result.data) }
+                    is DataResult.Failure -> { RecentlyResultUiState.Failed(result.message) }
                 }
-        }
-    }
+            }.stateIn(
+                scope = viewModelScope,
+                initialValue = RecentlyResultUiState.Loading,
+                started = SharingStarted.Eagerly
+            )
 }

--- a/feature/home/src/main/java/com/eshc/goonersapp/feature/home/state/RecentlyResultUiState.kt
+++ b/feature/home/src/main/java/com/eshc/goonersapp/feature/home/state/RecentlyResultUiState.kt
@@ -1,0 +1,13 @@
+package com.eshc.goonersapp.feature.home.state
+
+import com.eshc.goonersapp.core.domain.model.match.MatchRecently
+
+sealed interface RecentlyResultUiState {
+    data object Loading: RecentlyResultUiState
+
+    data class Success(val data: MatchRecently? = null): RecentlyResultUiState
+
+    data class Failed(val message: String? = null): RecentlyResultUiState
+
+    data class Error(val throwable: String? = null): RecentlyResultUiState
+}

--- a/feature/home/src/main/java/com/eshc/goonersapp/feature/home/state/UpcomingMatchesUiState.kt
+++ b/feature/home/src/main/java/com/eshc/goonersapp/feature/home/state/UpcomingMatchesUiState.kt
@@ -1,0 +1,14 @@
+package com.eshc.goonersapp.feature.home.state
+
+import com.eshc.goonersapp.core.domain.model.match.Match
+
+sealed interface UpcomingMatchesUiState {
+    data object Loading: UpcomingMatchesUiState
+
+    data class Success(val data: List<Match>): UpcomingMatchesUiState
+
+    data class Failed(val message: String? = null): UpcomingMatchesUiState
+
+    data class Error(val throwable: String? = null): UpcomingMatchesUiState
+
+}


### PR DESCRIPTION
## Description
 
HomeScreen과 HomeViewModel에 UpcomingMatchesUiState와 RecentlyResultMatchesUiState를 적용했습니다.

### Content 
 - UpcomingMatchesUiState가 추가되었습니다.
 - RecentlyResultUiState가 추가되었습니다.
 - State의 추가에 따른 HomeScreen과 HomeViewModel이 수정되었습니다.

### UpcomingMatchesUiState, RecentlyResultUiState의 구성
   1. Loading
    -  StateFlow가 시작될때 초기 값으로 사용됩니다.
   2. Success
    - Data를 불러오는 작업이 성공`DataResult.Success`한 경우 사용됩니다.
   3. Failed 
    - Data를 불러오는 작업이 실패`DataResult.Failed`한 경우 사용됩니다.
   4. Error 
    - useCase의 Flow를 실행하는 과정에서 예상치 못한 에러가 발생한 경우 (ex. IOException 등등) 사용되는 State입니다.
    - Flow의 catch 문에 배치되었으며 현재는 Throwable의 message를 받아 Screen에서 message를 출력해주는 용도로 사용합니다.
