### PR TITLE
[FEATURE] Modified Player Detail Screen (2)

### DIFF
--- a/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/__IconPack.kt
+++ b/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/__IconPack.kt
@@ -1,12 +1,7 @@
 package com.eshc.goonersapp.core.designsystem
 
 import androidx.compose.ui.graphics.vector.ImageVector
-import com.eshc.goonersapp.core.designsystem.iconpack.IcCalendarSelected
-import com.eshc.goonersapp.core.designsystem.iconpack.IcCalendarUnselected
-import com.eshc.goonersapp.core.designsystem.iconpack.IcHomeSelected
-import com.eshc.goonersapp.core.designsystem.iconpack.IcHomeUnselected
-import com.eshc.goonersapp.core.designsystem.iconpack.IcTeamSelected
-import com.eshc.goonersapp.core.designsystem.iconpack.IcTeamUnselected
+import com.eshc.goonersapp.core.designsystem.iconpack.IcArrowDown
 import kotlin.collections.List as ____KtList
 
 public object IconPack
@@ -18,7 +13,6 @@ public val IconPack.Icons: ____KtList<ImageVector>
     if (__Icons != null) {
       return __Icons!!
     }
-    __Icons= listOf(IcCalendarSelected, IcHomeSelected, IcTeamSelected, IcCalendarUnselected,
-        IcTeamUnselected, IcHomeUnselected)
+    __Icons= listOf(IcArrowDown)
     return __Icons!!
   }

--- a/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/component/DropdownMenu.kt
+++ b/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/component/DropdownMenu.kt
@@ -1,26 +1,20 @@
 package com.eshc.goonersapp.core.designsystem.component
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material3.Divider
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,22 +25,22 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.eshc.goonersapp.core.designsystem.IconPack
+import com.eshc.goonersapp.core.designsystem.iconpack.IcArrowDown
+import com.eshc.goonersapp.core.designsystem.theme.ColorFF777777
+import com.eshc.goonersapp.core.designsystem.theme.ColorFF9E9E9E
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFDCDCDC
+import com.eshc.goonersapp.core.designsystem.theme.GnrTypography
 import com.eshc.goonersapp.core.designsystem.theme.GoonersAppTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun <T> LargeDropdownMenu(
+fun <T> GnrDropdownMenu(
     modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    label: String,
+    label: String = "",
+    items: List<T> = emptyList(),
     notSetLabel: String? = null,
-    items: List<T>,
     selectedIndex: Int = -1,
     onItemSelected: (index: Int, item: T) -> Unit,
     selectedItemToString: (T) -> String = { it.toString() },
@@ -61,31 +55,29 @@ fun <T> LargeDropdownMenu(
 ) {
     var expanded by remember { mutableStateOf(false) }
 
-    Box(modifier = modifier.height(IntrinsicSize.Min)) {
-        OutlinedTextField(
-            label = { Text(label) },
-            value = items.getOrNull(selectedIndex)?.let { selectedItemToString(it) } ?: "",
-            enabled = enabled,
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(
-                corner = CornerSize(16.dp)
-            ),
-            trailingIcon = {
-                Icon(Icons.Filled.ArrowDropDown, "",modifier = Modifier.rotate(if(expanded) 180f else 0f))
-            },
-            onValueChange = { },
-            readOnly = true,
-        )
-
-        // Transparent clickable surface on top of OutlinedTextField
-        Surface(
+    OutlinedButton(
+        modifier = modifier,
+        colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = ColorFF9E9E9E
+        ),
+        border = BorderStroke(1.dp, ColorFFDCDCDC),
+        shape = RoundedCornerShape(100.dp),
+        onClick = {
+            expanded = true
+        }
+    ) {
+        Text(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(top = 8.dp)
-                .clip(MaterialTheme.shapes.extraSmall)
-                .clickable(enabled = enabled) { expanded = true },
-            color = Color.Transparent,
-        ) {}
+                .weight(1f)
+                .padding(end = 4.dp),
+            text = items.getOrNull(selectedIndex)?.let { selectedItemToString(it) } ?: label,
+            style = GnrTypography.body1Regular,
+            color = ColorFF777777
+        )
+        Icon(
+            imageVector = IconPack.IcArrowDown,
+            contentDescription = "down"
+        )
     }
 
     if (expanded) {
@@ -126,7 +118,7 @@ fun <T> LargeDropdownMenu(
                             }
 
                             if (index < items.lastIndex) {
-                                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                             }
                         }
                     }
@@ -144,9 +136,9 @@ fun LargeDropdownMenuItem(
     onClick: () -> Unit,
 ) {
     val contentColor = when {
-        !enabled -> MaterialTheme.colorScheme.onSurface//.copy(alpha = ALPHA_DISABLED)
-        selected -> MaterialTheme.colorScheme.primary//.copy(alpha = ALPHA_FULL)
-        else -> MaterialTheme.colorScheme.onSurface//.copy(alpha = ALPHA_FULL)
+        !enabled -> MaterialTheme.colorScheme.onSurface
+        selected -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.onSurface
     }
 
     CompositionLocalProvider(LocalContentColor provides contentColor) {

--- a/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/component/Tab.kt
+++ b/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/component/Tab.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF10358A
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF9E9E9E
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFDCDCDC
 import com.eshc.goonersapp.core.designsystem.theme.GnrTypography
 
 
@@ -29,16 +30,16 @@ fun GnrTabItem(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            modifier = Modifier.padding(bottom = 8.dp),
+            modifier = Modifier.padding(vertical = 10.dp),
             text = tabTitle,
             style = GnrTypography.body1SemiBold,
             color = if (isSelected) ColorFF10358A else ColorFF9E9E9E,
         )
-        if (isSelected)
-            HorizontalDivider(
-                modifier = Modifier,
-                color = ColorFF10358A,
-                thickness = 2.dp
-            )
+
+        HorizontalDivider(
+            modifier = Modifier,
+            color = if (isSelected) ColorFF10358A else ColorFFDCDCDC,
+            thickness = 2.dp
+        )
     }
 }

--- a/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/ext/ModifierExt.kt
+++ b/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/ext/ModifierExt.kt
@@ -1,0 +1,18 @@
+package com.eshc.goonersapp.core.designsystem.ext
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFF5F5F5
+
+fun Modifier.gnrElevatedCardBorder(
+    round : Dp
+) = this.then(
+    Modifier.border(
+        width = 1.dp,
+        color = ColorFFF5F5F5,
+        shape = RoundedCornerShape(round)
+    )
+)

--- a/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/iconpack/IcArrowDown.kt
+++ b/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/iconpack/IcArrowDown.kt
@@ -1,0 +1,46 @@
+package com.eshc.goonersapp.core.designsystem.iconpack
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import com.eshc.goonersapp.core.designsystem.IconPack
+
+public val IconPack.IcArrowDown: ImageVector
+    get() {
+        if (_icArrowDown != null) {
+            return _icArrowDown!!
+        }
+        _icArrowDown = Builder(name = "IcArrowDown", defaultWidth = 14.0.dp, defaultHeight = 8.0.dp,
+                viewportWidth = 14.0f, viewportHeight = 8.0f).apply {
+            path(fill = SolidColor(Color(0xFF9E9E9E)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero) {
+                moveTo(13.7394f, 1.5981f)
+                lineTo(7.8906f, 7.6024f)
+                curveTo(7.7562f, 7.7404f, 7.6172f, 7.8412f, 7.4737f, 7.9047f)
+                curveTo(7.3301f, 7.9682f, 7.1722f, 8.0f, 7.0f, 8.0f)
+                curveTo(6.8278f, 8.0f, 6.6699f, 7.9682f, 6.5263f, 7.9047f)
+                curveTo(6.3828f, 7.8412f, 6.2438f, 7.7404f, 6.1094f, 7.6024f)
+                lineTo(0.2602f, 1.5978f)
+                curveTo(0.1796f, 1.5149f, 0.116f, 1.4224f, 0.0696f, 1.3203f)
+                curveTo(0.0232f, 1.2181f, -0.0f, 1.1087f, -0.0f, 0.9919f)
+                curveTo(-0.0f, 0.7584f, 0.0769f, 0.5556f, 0.2307f, 0.3833f)
+                curveTo(0.3845f, 0.2111f, 0.5872f, 0.125f, 0.8389f, 0.125f)
+                lineTo(13.1611f, 0.125f)
+                curveTo(13.4128f, 0.125f, 13.6155f, 0.2119f, 13.7693f, 0.3858f)
+                curveTo(13.9231f, 0.5597f, 14.0f, 0.7626f, 14.0f, 0.9945f)
+                curveTo(14.0f, 1.0524f, 13.9131f, 1.2537f, 13.7394f, 1.5981f)
+                close()
+            }
+        }
+        .build()
+        return _icArrowDown!!
+    }
+
+private var _icArrowDown: ImageVector? = null

--- a/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/theme/Color.kt
@@ -16,6 +16,7 @@ val ColorFF889AC4 = Color(0xFF889AC4)
 val ColorFFC3CDE2 = Color(0xFFC3CDE2)
 val ColorFFF7F9FF = Color(0xFFF7F9FF)
 
+val ColorFF000000 = Color(0xFF000000)
 val ColorFF181818 = Color(0xFF181818)
 val ColorFF555555 = Color(0xFF555555)
 val ColorFF777777 = Color(0xFF777777)

--- a/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/theme/Color.kt
@@ -27,3 +27,6 @@ val ColorFFDCDCDC = Color(0xFFDCDCDC)
 val ColorFFF5F5F5 = Color(0xFFF5F5F5)
 val ColorFFFAFAFC = Color(0xFFFAFAFC)
 val ColorFFFFFFFF = Color(0xFFFFFFFF)
+
+val ColorFFFECD44 = Color(0xFFFECD44)
+val ColorFFE9343C = Color(0xFFE9343C)

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
     implementation(libs.hilt.core)
     implementation(libs.kotlinx.coroutines)
     kapt(libs.hilt.compiler)
+    implementation(project(":core:common"))
 }

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/player/Player.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/player/Player.kt
@@ -1,5 +1,9 @@
 package com.eshc.goonersapp.core.domain.model.player
 
+import com.eshc.goonersapp.core.common.util.DateUtil.getYearAndMonthAndDateLocalDate
+import java.time.LocalDate
+import java.time.Period
+
 data class Player(
     val id :Int,
     val name : String = "",
@@ -30,6 +34,13 @@ data class Player(
 
     val displayName : String
         get() = firstName + (if(lastNames.isEmpty()) "" else "\n${lastNames}")
+
+    fun getAge() : Int {
+        return Period.between(
+            getYearAndMonthAndDateLocalDate(birthDate),
+            LocalDate.now()
+        ).years
+    }
 
 }
 

--- a/feature/home/src/main/java/com/eshc/goonersapp/feature/home/component/MatchCard.kt
+++ b/feature/home/src/main/java/com/eshc/goonersapp/feature/home/component/MatchCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.eshc.goonersapp.core.designsystem.component.GnrElevatedCard
+import com.eshc.goonersapp.core.designsystem.ext.gnrElevatedCardBorder
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF10358A
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF181818
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF4C68A7
@@ -74,11 +75,7 @@ fun RecentlyMatchCard(
             .padding(horizontal = 8.dp, vertical = 12.dp)
             .fillMaxWidth()
             .height(IntrinsicSize.Max)
-            .border(
-                width = 1.dp,
-                color = ColorFFF5F5F5,
-                shape = RoundedCornerShape(10.dp)
-            ),
+            .gnrElevatedCardBorder(10.dp),
         colors = CardDefaults.cardColors(containerColor = Color.White),
         radius = 10.dp
     ) {
@@ -179,11 +176,7 @@ fun UpcomingMatchCard(
         modifier = modifier
             .width(263.dp)
             .height(131.dp)
-            .border(
-                width = 1.dp,
-                color = ColorFFF5F5F5,
-                shape = RoundedCornerShape(10.dp)
-            )
+            .gnrElevatedCardBorder(10.dp)
     ) {
         Column(
             modifier = modifier

--- a/feature/team/src/main/java/com/eshc/goonersapp/feature/team/TeamScreen.kt
+++ b/feature/team/src/main/java/com/eshc/goonersapp/feature/team/TeamScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.eshc.goonersapp.core.designsystem.component.LargeDropdownMenu
+import com.eshc.goonersapp.core.designsystem.component.GnrDropdownMenu
 import com.eshc.goonersapp.core.domain.model.player.Player
 import com.eshc.goonersapp.core.domain.model.player.PlayerPosition
 import com.eshc.goonersapp.feature.team.state.TeamUiState
@@ -75,7 +75,7 @@ fun ColumnScope.TeamScreen(
     onClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LargeDropdownMenu(
+    GnrDropdownMenu(
         modifier = Modifier.padding(horizontal = 24.dp),
         label = "season",
         items = listOf("2023-2024","2022-2023"),

--- a/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/PlayerDetailScreen.kt
+++ b/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/PlayerDetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,6 +44,7 @@ import com.eshc.goonersapp.core.designsystem.component.GnrElevatedCard
 import com.eshc.goonersapp.core.designsystem.component.GnrTabItem
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF10358A
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF181818
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFF5F5F5
 import com.eshc.goonersapp.core.designsystem.theme.ColorFFFFFFFF
 import com.eshc.goonersapp.core.designsystem.theme.GnrTypography
 import com.eshc.goonersapp.core.domain.model.player.Player
@@ -99,7 +101,7 @@ fun PlayerDetailScreen(
                             ) {
                                 PlayerDetailInfo(
                                     title = "Age",
-                                    content = "22"
+                                    content = "${player.getAge()}"
                                 )
                                 PlayerDetailInfo(
                                     title = "Games",
@@ -110,16 +112,22 @@ fun PlayerDetailScreen(
                                     content = "10"
                                 )
                             }
+
+                            HorizontalDivider(
+                                modifier = Modifier.padding(top = 14.dp),
+                                thickness = 7.dp,
+                                color = ColorFFF5F5F5
+                            )
                         }
 
                         item {
                             Row(
-                                modifier = Modifier.fillMaxWidth().padding(horizontal = 15.dp),
-                                horizontalArrangement = Arrangement.spacedBy(24.dp)
+                                modifier = Modifier
+                                    .fillMaxWidth()
                             ) {
                                 DetailTab.entries.forEach {
                                     GnrTabItem(
-                                        modifier = Modifier.width(IntrinsicSize.Max),
+                                        modifier = Modifier.weight(1f),
                                         tabTitle = it.name,
                                         isSelected = selectedTab == it,
                                         onSelect = {

--- a/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/PlayerDetailScreen.kt
+++ b/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/PlayerDetailScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.aspectRatio
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
@@ -42,6 +40,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.eshc.goonersapp.core.designsystem.component.GnrElevatedCard
 import com.eshc.goonersapp.core.designsystem.component.GnrTabItem
+import com.eshc.goonersapp.core.designsystem.ext.gnrElevatedCardBorder
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF10358A
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF181818
 import com.eshc.goonersapp.core.designsystem.theme.ColorFFF5F5F5
@@ -267,7 +266,8 @@ fun RowScope.PlayerDetailInfo(
     GnrElevatedCard(
         modifier = Modifier
             .height(110.dp)
-            .weight(1f),
+            .weight(1f)
+            .gnrElevatedCardBorder(15.dp),
         radius = 15.dp,
         colors = CardDefaults.elevatedCardColors(
             containerColor = ColorFFFFFFFF

--- a/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/ProfileScreen.kt
+++ b/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/ProfileScreen.kt
@@ -1,31 +1,20 @@
 package com.eshc.goonersapp.feature.team.detail
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.eshc.goonersapp.core.common.util.DateUtil
 import com.eshc.goonersapp.core.common.util.DateUtil.getYearAndMonthAndDateString
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF000000
-import com.eshc.goonersapp.core.designsystem.theme.ColorFF181818
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF777777
 import com.eshc.goonersapp.core.designsystem.theme.ColorFFDCDCDC
 import com.eshc.goonersapp.core.designsystem.theme.GnrTypography
@@ -57,7 +46,7 @@ fun ProfileScreen(
         )
         ProfileContent(
             title = stringResource(id = R.string.player_detail_profile_nationality),
-            description =  "Bosnia and Herzegovina",
+            description =  player.nationality,
             modifier = Modifier.fillMaxWidth()
         )
         ProfileContent(

--- a/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/ProfileScreen.kt
+++ b/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/ProfileScreen.kt
@@ -2,117 +2,96 @@ package com.eshc.goonersapp.feature.team.detail
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.eshc.goonersapp.core.common.util.DateUtil
+import com.eshc.goonersapp.core.common.util.DateUtil.getYearAndMonthAndDateString
+import com.eshc.goonersapp.core.designsystem.theme.ColorFF000000
+import com.eshc.goonersapp.core.designsystem.theme.ColorFF181818
+import com.eshc.goonersapp.core.designsystem.theme.ColorFF777777
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFDCDCDC
+import com.eshc.goonersapp.core.designsystem.theme.GnrTypography
 import com.eshc.goonersapp.core.domain.model.player.Player
+import com.eshc.goonersapp.feature.team.R
 
 @Composable
 fun ProfileScreen(
-    player : Player
+    player : Player,
+    modifier: Modifier = Modifier
 ) {
-    OutlinedCard(
-        modifier = Modifier
-            .padding(start = 16.dp, end = 16.dp, top = 24.dp)
-            .fillMaxWidth()
-            .wrapContentHeight(),
-        border = BorderStroke(width = 1.dp, color = Color(0xFFF1F1F1)),
-        colors = CardDefaults.outlinedCardColors(
-            containerColor = Color.Transparent
-        )
-
+    Column(
+        modifier = modifier.fillMaxSize().padding(horizontal = 15.dp, vertical = 20.dp)
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        ){
-            Column(
-                modifier = Modifier.weight(1f)
-            ) {
-                Text(
-                    text = "Date Of Birth",
-                    textAlign = TextAlign.Center,
-                    color = Color.Gray,
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    text = DateUtil.getYearAndMonthAndDateString(player.birthDate),
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color.Black,
-                )
-                Spacer(modifier = Modifier.height(10.dp))
-                Text(
-                    text = "Position",
-                    textAlign = TextAlign.Center,
-                    color = Color.Gray,
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    text = player.position,
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color.Black,
-                )
-                Spacer(modifier = Modifier.height(10.dp))
-                Text(
-                    text = "Weight",
-                    textAlign = TextAlign.Center,
-                    color = Color.Gray,
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    text = "${player.weight}kg",
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color.Black,
-                )
-            }
-            Column(
-                modifier = Modifier.weight(1f)
-            ) {
-                Text(
-                    text = "Nationality",
-                    textAlign = TextAlign.Center,
-                    color = Color.Gray,
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    text = player.nationality,
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color.Black,
-                )
-                Spacer(modifier = Modifier.height(10.dp))
-                Text(
-                    text = "Height",
-                    textAlign = TextAlign.Center,
-                    color = Color.Gray,
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    text = "${player.height}cm",
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color.Black,
-                )
-            }
-        }
-
-
+        ProfileContent(
+            title = stringResource(id = R.string.player_detail_profile_date_of_birth),
+            description = getYearAndMonthAndDateString(player.birthDate),
+            modifier = Modifier.fillMaxWidth()
+        )
+        ProfileContent(
+            title = stringResource(id = R.string.player_detail_profile_height),
+            description = "${player.height}cm",
+            modifier = Modifier.fillMaxWidth()
+        )
+        ProfileContent(
+            title = stringResource(id = R.string.player_detail_profile_weight),
+            description = "${player.weight}kg",
+            modifier = Modifier.fillMaxWidth()
+        )
+        ProfileContent(
+            title = stringResource(id = R.string.player_detail_profile_nationality),
+            description =  "Bosnia and Herzegovina",
+            modifier = Modifier.fillMaxWidth()
+        )
+        ProfileContent(
+            title = stringResource(id = R.string.player_detail_profile_position),
+            description = player.position,
+            modifier = Modifier.fillMaxWidth()
+        )
     }
+}
+
+@Composable
+fun ColumnScope.ProfileContent(
+    title : String,
+    description : String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.padding(horizontal = 15.dp, vertical = 14.dp)
+    ) {
+        Text(
+            modifier = Modifier.width(128.dp),
+            text = title,
+            style = GnrTypography.body1Regular,
+            color = ColorFF777777
+        )
+        Text(
+            text = description,
+            style = GnrTypography.body1Medium,
+            color = ColorFF000000
+        )
+    }
+    HorizontalDivider(
+        modifier = modifier,
+        color = ColorFFDCDCDC,
+        thickness = 1.dp
+    )
 }

--- a/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/StatScreen.kt
+++ b/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/StatScreen.kt
@@ -1,6 +1,5 @@
 package com.eshc.goonersapp.feature.team.detail
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -16,19 +15,17 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.eshc.goonersapp.core.designsystem.component.GnrElevatedCard
-import com.eshc.goonersapp.core.designsystem.component.LargeDropdownMenu
+import com.eshc.goonersapp.core.designsystem.component.GnrDropdownMenu
+import com.eshc.goonersapp.core.designsystem.ext.gnrElevatedCardBorder
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF000000
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF777777
 import com.eshc.goonersapp.core.designsystem.theme.ColorFFDCDCDC
@@ -36,7 +33,6 @@ import com.eshc.goonersapp.core.designsystem.theme.ColorFFE9343C
 import com.eshc.goonersapp.core.designsystem.theme.ColorFFFECD44
 import com.eshc.goonersapp.core.designsystem.theme.ColorFFFFFFFF
 import com.eshc.goonersapp.core.designsystem.theme.GnrTypography
-import com.eshc.goonersapp.core.designsystem.theme.pretendard
 
 @Composable
 fun StatScreen(
@@ -66,7 +62,8 @@ fun TotalStatCard(
     modifier: Modifier = Modifier,
 ) {
     GnrElevatedCard(
-        modifier = modifier.padding(vertical = 20.dp, horizontal = 14.dp),
+        modifier = modifier.padding(vertical = 20.dp, horizontal = 14.dp)
+            .gnrElevatedCardBorder(15.dp),
         radius = 15.dp,
         colors = CardDefaults.elevatedCardColors(
             containerColor = ColorFFFFFFFF

--- a/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/StatScreen.kt
+++ b/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/StatScreen.kt
@@ -45,9 +45,10 @@ fun StatScreen(
     Column(
         modifier = modifier.fillMaxSize()
     ) {
-        LargeDropdownMenu(
-            modifier = Modifier.padding(horizontal = 24.dp),
+        GnrDropdownMenu(
+            modifier = Modifier.padding(start = 14.dp,end = 14.dp, top = 26.dp),
             label = "season",
+            selectedIndex = 0,
             items = listOf("2023-2024", "2022-2023"),
             onItemSelected = { index, item ->
                 //TODO

--- a/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/StatScreen.kt
+++ b/feature/team/src/main/java/com/eshc/goonersapp/feature/team/detail/StatScreen.kt
@@ -1,8 +1,11 @@
 package com.eshc.goonersapp.feature.team.detail
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,87 +13,48 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.eshc.goonersapp.core.designsystem.component.GnrElevatedCard
+import com.eshc.goonersapp.core.designsystem.component.LargeDropdownMenu
+import com.eshc.goonersapp.core.designsystem.theme.ColorFF000000
+import com.eshc.goonersapp.core.designsystem.theme.ColorFF777777
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFDCDCDC
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFE9343C
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFFECD44
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFFFFFFF
+import com.eshc.goonersapp.core.designsystem.theme.GnrTypography
 import com.eshc.goonersapp.core.designsystem.theme.pretendard
 
 @Composable
-fun StatScreen(){
+fun StatScreen(
+    modifier: Modifier = Modifier
+) {
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = modifier.fillMaxSize()
     ) {
-        OutlinedCard(
-            modifier = Modifier
-                .padding(start = 16.dp, end = 16.dp, top = 24.dp)
-                .fillMaxWidth()
-                .wrapContentHeight(),
-            border = BorderStroke(width = 1.dp, color = Color(0xFFF1F1F1)),
-            colors = CardDefaults.outlinedCardColors(
-                containerColor = Color.Transparent
-            )
+        LargeDropdownMenu(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            label = "season",
+            items = listOf("2023-2024", "2022-2023"),
+            onItemSelected = { index, item ->
+                //TODO
+            }
+        )
 
-        ) {
-            Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp),
-                text = "2023-2024",
-                textAlign = TextAlign.Center,
-                fontFamily = pretendard,
-                fontWeight = FontWeight.Bold,
-                color = Color.Black,
-                fontSize = 16.sp,
-                letterSpacing = 0.1.sp
-            )
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
-        ){
-            TotalStatCard(
-                modifier = Modifier
-                    .wrapContentHeight()
-                    .weight(1f),
-                statType = StatType.APPEARANCES,
-                18
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            TotalStatCard(
-                modifier = Modifier
-                    .wrapContentHeight()
-                    .weight(1f),
-                statType = StatType.GOALS,
-                8
-            )
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
-        ){
-            TotalStatCard(
-                modifier = Modifier
-                    .wrapContentHeight()
-                    .weight(1f),
-                statType = StatType.ASSISTS,
-                10
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            TotalStatCard(
-                modifier = Modifier
-                    .wrapContentHeight()
-                    .weight(1f),
-                statType = StatType.MOTM,
-                4
-            )
-        }
+        TotalStatCard()
 
 
     }
@@ -99,43 +63,115 @@ fun StatScreen(){
 @Composable
 fun TotalStatCard(
     modifier: Modifier = Modifier,
-    statType: StatType,
-    count : Int
 ) {
-    OutlinedCard(
-        modifier = modifier,
-        border = BorderStroke(width = 1.dp, color = Color(0xFFF1F1F1)),
-        colors = CardDefaults.outlinedCardColors(
-            containerColor = Color.Transparent
+    GnrElevatedCard(
+        modifier = modifier.padding(vertical = 20.dp, horizontal = 14.dp),
+        radius = 15.dp,
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = ColorFFFFFFFF
         )
-
     ) {
         Column(
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(vertical = 24.dp)
         ) {
-            Text(
-                text = statType.name,
-                textAlign = TextAlign.Center,
-                fontFamily = pretendard,
-                fontWeight = FontWeight.Bold,
-                color = Color.Black,
-                fontSize = 16.sp,
-                letterSpacing = 0.1.sp
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+            ) {
+                StatContent(
+                    title = "Matches Played",
+                    description = "9"
+                )
+                StatContent(
+                    title = "Goals",
+                    description = "10"
+                )
+            }
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 18.dp),
+                color = ColorFFDCDCDC,
+                thickness = 1.dp
             )
-            Text(
-                text = "$count",
-                textAlign = TextAlign.Center,
-                fontFamily = pretendard,
-                fontWeight = FontWeight.Bold,
-                color = Color.Black,
-                fontSize = 60.sp,
-                letterSpacing = 0.1.sp
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+            ) {
+                StatContentWithColorChip(
+                    title = "Yellow Cards",
+                    description = "0",
+                    color = ColorFFFECD44
+                )
+                StatContentWithColorChip(
+                    title = "Red Cards",
+                    description = "0",
+                    color = ColorFFE9343C
+                )
+            }
         }
 
     }
 }
 
-enum class StatType {
-    APPEARANCES, GOALS, ASSISTS,MOTM
+@Composable
+fun RowScope.StatContent(
+    title: String,
+    description: String
+) {
+    Column(
+        modifier = Modifier
+            .wrapContentHeight()
+            .weight(1f),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(
+            text = title,
+            style = GnrTypography.body2Regular,
+            color = ColorFF777777
+        )
+        Text(
+            text = description,
+            style = GnrTypography.heading1SemiBold,
+            color = ColorFF000000
+        )
+    }
+}
+
+@Composable
+fun RowScope.StatContentWithColorChip(
+    title: String,
+    description: String,
+    color: Color
+) {
+    Column(
+        modifier = Modifier
+            .wrapContentHeight()
+            .weight(1f),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(
+            text = title,
+            style = GnrTypography.body2Regular,
+            color = ColorFF777777
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(7.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Spacer(
+                modifier = Modifier
+                    .width(13.dp)
+                    .height(20.dp)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(color)
+            )
+            Text(
+                text = description,
+                style = GnrTypography.heading1SemiBold,
+                color = ColorFF000000
+            )
+        }
+
+    }
 }

--- a/feature/team/src/main/java/com/eshc/goonersapp/feature/team/history/TeamHistoryScreen.kt
+++ b/feature/team/src/main/java/com/eshc/goonersapp/feature/team/history/TeamHistoryScreen.kt
@@ -2,11 +2,8 @@ package com.eshc.goonersapp.feature.team.history
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import com.eshc.goonersapp.core.designsystem.component.LargeDropdownMenu
 import com.eshc.goonersapp.core.designsystem.component.TopBar
 
 @Composable

--- a/feature/team/src/main/res/values/strings.xml
+++ b/feature/team/src/main/res/values/strings.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="team">Team</string>
+
+    <string name="player_detail_profile_date_of_birth">Date Of Birth</string>
+    <string name="player_detail_profile_height">Height</string>
+    <string name="player_detail_profile_weight">Weight</string>
+    <string name="player_detail_profile_nationality">Nationality</string>
+    <string name="player_detail_profile_position">Position</string>
+
 </resources>


### PR DESCRIPTION
## Description
 - 수정된 디자인에 따른 PlayerDetailScreen UI 하단 부분 수정

### Content
 1. 디자인 변경에 따른 GnrTab 재수정
 2. Dropdown 수정
 3. 선수 상세 하단 UI 수정

## Result screenshot
<img width="280" src="https://github.com/eshc123/GoonersApp/assets/50227341/0a0c03fa-47a4-49bb-a08d-b60c43345e62">
<img width="280" src="https://github.com/eshc123/GoonersApp/assets/50227341/2911cf23-44e5-4ebe-87d0-21a88c6ae9d0">


### Comment
Stat, Matches 모두 현재는 API 미구현이지만 Stat API 관련 작업을 선행할 것 같아 Stat은 UI를 그려두었습니다.

MatchCard에서 사용되고 있던
```
border(
        width = 1.dp,
        color = ColorFFF5F5F5,
        shape = RoundedCornerShape(round)
    )
```
를 확장함수 형태로 빼서 공통적으로 사용하게 수정하였습니다.
```
fun Modifier.gnrElevatedCardBorder(
    round : Dp
) = this.then(
    Modifier.border(
        width = 1.dp,
        color = ColorFFF5F5F5,
        shape = RoundedCornerShape(round)
    )
)
```