### PR TITLE
[FEATURE] Player Network Test

### DIFF
--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakePlayerNetworkDataSource.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakePlayerNetworkDataSource.kt
@@ -2,26 +2,38 @@ package com.eshc.goonersapp.core.network.fake
 
 import com.eshc.goonersapp.core.network.PlayerNetworkDataSource
 import com.eshc.goonersapp.core.network.model.NetworkResult
+import com.eshc.goonersapp.core.network.model.match.RemoteMatch
+import com.eshc.goonersapp.core.network.model.match.RemoteMatchData
 import com.eshc.goonersapp.core.network.model.player.RemotePlayer
 
 class FakePlayerNetworkDataSource : PlayerNetworkDataSource {
 
-    private var responseForPlayerList : (() -> NetworkResult<List<RemotePlayer>>)? = null
-    private var responseForPlayerDetail : (() -> NetworkResult<RemotePlayer>)? = null
+    private var responseForPlayerList: (() -> List<RemotePlayer>)? = null
+    private var responseForPlayerDetail: (() -> RemotePlayer)? = null
 
-    fun setResponseForPlayerList(response: () -> NetworkResult<List<RemotePlayer>>) {
+    fun setResponseForPlayerList(response: () -> List<RemotePlayer>) {
         this.responseForPlayerList = response
     }
 
-    fun setResponseForPlayerDetail(response: () -> NetworkResult<RemotePlayer>) {
+    fun setResponseForPlayerDetail(response: () -> RemotePlayer) {
         this.responseForPlayerDetail = response
     }
 
     override suspend fun getPlayerList(): NetworkResult<List<RemotePlayer>> {
-        return responseForPlayerList?.invoke() ?: throw IllegalStateException("Response for getPlayerList not set")
+        val response = responseForPlayerList?.invoke()
+        return if (response != null) {
+            NetworkResult.Success(response)
+        } else {
+            NetworkResult.Error(code = 404, message = "Response for getPlayerList not se")
+        }
     }
 
     override suspend fun getPlayerDetail(playerId: Int): NetworkResult<RemotePlayer> {
-        return responseForPlayerDetail?.invoke() ?: throw IllegalStateException("Response for getPlayerDetail not set")
+        val response = responseForPlayerDetail?.invoke()
+        return if (response != null) {
+            NetworkResult.Success(response)
+        } else {
+            NetworkResult.Error(code = 404, message = "Response for getPlayerList not se")
+        }
     }
 }

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakePlayerNetworkDataSource.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakePlayerNetworkDataSource.kt
@@ -11,11 +11,11 @@ class FakePlayerNetworkDataSource : PlayerNetworkDataSource {
     private var responseForPlayerList: (() -> List<RemotePlayer>)? = null
     private var responseForPlayerDetail: (() -> RemotePlayer)? = null
 
-    fun setResponseForPlayerList(response: () -> List<RemotePlayer>) {
+    fun setResponseForPlayerList(response:( () -> List<RemotePlayer>)?) {
         this.responseForPlayerList = response
     }
 
-    fun setResponseForPlayerDetail(response: () -> RemotePlayer) {
+    fun setResponseForPlayerDetail(response: (() -> RemotePlayer)?) {
         this.responseForPlayerDetail = response
     }
 
@@ -24,7 +24,7 @@ class FakePlayerNetworkDataSource : PlayerNetworkDataSource {
         return if (response != null) {
             NetworkResult.Success(response)
         } else {
-            NetworkResult.Error(code = 404, message = "Response for getPlayerList not se")
+            NetworkResult.Error(code = 404, message = "Response for getPlayerList not sent")
         }
     }
 
@@ -33,7 +33,7 @@ class FakePlayerNetworkDataSource : PlayerNetworkDataSource {
         return if (response != null) {
             NetworkResult.Success(response)
         } else {
-            NetworkResult.Error(code = 404, message = "Response for getPlayerList not se")
+            NetworkResult.Error(code = 404, message = "Response for getPlayerDetail not sent")
         }
     }
 }

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakePlayerNetworkDataSource.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakePlayerNetworkDataSource.kt
@@ -1,0 +1,27 @@
+package com.eshc.goonersapp.core.network.fake
+
+import com.eshc.goonersapp.core.network.PlayerNetworkDataSource
+import com.eshc.goonersapp.core.network.model.NetworkResult
+import com.eshc.goonersapp.core.network.model.player.RemotePlayer
+
+class FakePlayerNetworkDataSource : PlayerNetworkDataSource {
+
+    private var responseForPlayerList : (() -> NetworkResult<List<RemotePlayer>>)? = null
+    private var responseForPlayerDetail : (() -> NetworkResult<RemotePlayer>)? = null
+
+    fun setResponseForPlayerList(response: () -> NetworkResult<List<RemotePlayer>>) {
+        this.responseForPlayerList = response
+    }
+
+    fun setResponseForPlayerDetail(response: () -> NetworkResult<RemotePlayer>) {
+        this.responseForPlayerDetail = response
+    }
+
+    override suspend fun getPlayerList(): NetworkResult<List<RemotePlayer>> {
+        return responseForPlayerList?.invoke() ?: throw IllegalStateException("Response for getPlayerList not set")
+    }
+
+    override suspend fun getPlayerDetail(playerId: Int): NetworkResult<RemotePlayer> {
+        return responseForPlayerDetail?.invoke() ?: throw IllegalStateException("Response for getPlayerDetail not set")
+    }
+}

--- a/core/network/src/test/java/com/eshc/goonersapp/core/network/FakePlayerDataSourceTest.kt
+++ b/core/network/src/test/java/com/eshc/goonersapp/core/network/FakePlayerDataSourceTest.kt
@@ -1,0 +1,116 @@
+package com.eshc.goonersapp.core.network
+
+import com.eshc.goonersapp.core.network.fake.FakePlayerNetworkDataSource
+import com.eshc.goonersapp.core.network.model.NetworkResult
+import com.eshc.goonersapp.core.network.model.player.RemotePlayer
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Created By Jung SeokJoon
+ *
+ * [FakePlayerDataSourceTest]
+ *  - [FakePlayerNetworkDataSource] test codes
+ */
+
+class FakePlayerDataSourceTest {
+    private lateinit var fakePlayerNetworkDataSource: FakePlayerNetworkDataSource
+    private val player = RemotePlayer(playerId = 1)
+    private val playerList = listOf(player)
+
+    @Before
+    fun setUp() {
+        fakePlayerNetworkDataSource = FakePlayerNetworkDataSource()
+    }
+
+    @Test
+    fun `fake_get_player_list_as_success`() = runBlocking {
+        fakePlayerNetworkDataSource.setResponseForPlayerList {
+            playerList
+        }
+
+        when (val result = fakePlayerNetworkDataSource.getPlayerList()) {
+            is NetworkResult.Success -> {
+                Assert.assertEquals(
+                    playerList,
+                    result.data
+                )
+            }
+
+            is NetworkResult.Error -> {
+                fail("Test should not reach here, expected NetworkResult.Success")
+            }
+
+            is NetworkResult.Exception -> {
+                fail("Test should not reach here, expected NetworkResult.Success")
+            }
+        }
+    }
+
+    @Test
+    fun `fake_get_player_list_as_error`() = runBlocking {
+        fakePlayerNetworkDataSource.setResponseForPlayerList(null)
+
+        when (val result = fakePlayerNetworkDataSource.getPlayerList()) {
+            is NetworkResult.Success -> {
+                fail("Test should not reach here, expected NetworkResult.Error")
+            }
+
+            is NetworkResult.Error -> {
+                Assert.assertEquals(404, result.code)
+            }
+
+            is NetworkResult.Exception -> {
+                fail("Test should not reach here, expected NetworkResult.Error")
+            }
+        }
+    }
+
+    @Test
+    fun `fake_get_player_detail_as_success`() = runBlocking {
+        fakePlayerNetworkDataSource.setResponseForPlayerDetail {
+            player
+        }
+
+        when (val result = fakePlayerNetworkDataSource.getPlayerDetail(playerId = 1)) {
+            is NetworkResult.Success -> {
+                Assert.assertEquals(
+                    player,
+                    result.data
+                )
+            }
+
+            is NetworkResult.Error -> {
+                fail("Test should not reach here, expected NetworkResult.Success")
+            }
+
+            is NetworkResult.Exception -> {
+                fail("Test should not reach here, expected NetworkResult.Success")
+            }
+        }
+    }
+
+    @Test
+    fun `fake_get_player_detail_as_error`() = runBlocking {
+        fakePlayerNetworkDataSource.setResponseForPlayerDetail(null)
+
+        when (val result = fakePlayerNetworkDataSource.getPlayerDetail(playerId = 1)) {
+            is NetworkResult.Success -> {
+                fail("Test should not reach here, expected NetworkResult.Error")
+            }
+
+            is NetworkResult.Error -> {
+                Assert.assertEquals(404, result.code)
+            }
+
+            is NetworkResult.Exception -> {
+                fail("Test should not reach here, expected NetworkResult.Error")
+            }
+        }
+    }
+
+
+}

--- a/core/network/src/test/java/com/eshc/goonersapp/core/network/RemotePlayerApiTest.kt
+++ b/core/network/src/test/java/com/eshc/goonersapp/core/network/RemotePlayerApiTest.kt
@@ -1,0 +1,77 @@
+package com.eshc.goonersapp.core.network
+
+import com.eshc.goonersapp.core.network.api.PlayerNetworkService
+import com.eshc.goonersapp.core.network.api.SeasonNetworkService
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+
+/**
+ * Created By Jung SeokJoon
+ *
+ * [RemotePlayerApiTest]
+ *  - Gooners api Player local unit test
+ *  - this test is real network api call test
+ */
+class RemotePlayerApiTest {
+    private val responseOkCode = 200
+    private val baseUrl = BuildConfig.GNR_BASE_URL
+    private val networkJson = Json { ignoreUnknownKeys = true }
+
+    private lateinit var okHttpClient: OkHttpClient
+    private lateinit var retrofit: Retrofit
+    private lateinit var playerApi: PlayerNetworkService
+
+    @Before
+    fun initNetworkInstances() {
+        okHttpClient = OkHttpClient
+            .Builder()
+            .addInterceptor(HttpLoggingInterceptor())
+            .build()
+
+        retrofit = Retrofit
+            .Builder()
+            .baseUrl(baseUrl)
+            .addConverterFactory(
+                networkJson.asConverterFactory("application/json".toMediaType())
+            )
+            .client(okHttpClient)
+            .build()
+
+        playerApi = retrofit.create(PlayerNetworkService::class.java)
+    }
+
+
+    /**
+     * (Test Passed)
+     *
+     * Player List network communication test
+     *  - when response code is 200, Test Passed
+     */
+    @Test
+    fun test_GET_PLAYER_LIST_RESPONSE_IS_OK() = runBlocking {
+        val response = playerApi.getPlayers()
+        assertEquals(responseOkCode, response.code())
+        println(response.body())
+    }
+
+    /**
+     * (Test Passed)
+     *
+     * Player Detail network communication test
+     *  - when response code is 200, Test Passed
+     */
+    @Test
+    fun test_GET_PLAYER_DETAIL_RESPONSE_IS_OK() = runBlocking {
+        val response = playerApi.getPlayerDetail(playerId = 1494446)
+        assertEquals(responseOkCode, response.code())
+        println(response.body())
+    }
+}


### PR DESCRIPTION
## Description
 - Player Nework Test 추가

### Content
 1. RemotePlayerApiTest 추가
 2. FakePlayerNetworkDataSource 추가
 3. FakePlayerDataSourceTest 추가

### Comment
테스트 실행 시 Success와 Error 명확하게 나누고 원하는 결과를 테스트하기 위해 `FakePlayerNetworkDataSource ` 에서 `setResponseForPlayerList ` 와 같은 set 함수를 두었습니다.