### PR TITLE
[FEATURE] Modified Match Detail Screen (2) 

### DIFF
--- a/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/eshc/goonersapp/core/designsystem/theme/Color.kt
@@ -36,6 +36,8 @@ val Color88FFFFFF = Color(0x88FFFFFF)
 val ColorFFFECD44 = Color(0xFFFECD44)
 val ColorFFE9343C = Color(0xFFE9343C)
 
+val ColorFFE6EDFC = Color(0xFFE6EDFC)
+
 val BrushMainGradient = Brush.verticalGradient(
     listOf(
         ColorFF10358A,

--- a/feature/match/src/main/java/com/eshc/goonersapp/feature/match/component/formation/FootballFieldBox.kt
+++ b/feature/match/src/main/java/com/eshc/goonersapp/feature/match/component/formation/FootballFieldBox.kt
@@ -37,9 +37,6 @@ fun FootballFieldBox(
     modifier: Modifier = Modifier,
     rotateDegree : Float = 0f
 ) {
-    var firstCircle by remember { mutableStateOf(Pair(0.5f, 0.125f)) }
-    var boxSize by remember { mutableStateOf(Triple<Float, Float, Boolean>(0f, 0f, true)) }
-
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -49,13 +46,7 @@ fun FootballFieldBox(
         contentAlignment = Alignment.Center
     ) {
         Canvas(
-            modifier = modifier.onGloballyPositioned {
-                boxSize = Triple(
-                    it.size.width.toFloat(),
-                    it.size.height.toFloat(),
-                    boxSize.second > it.size.height.toFloat()
-                )
-            }
+            modifier = modifier
         ) {
             drawArc(
                 color = Color88FFFFFF,
@@ -127,32 +118,7 @@ fun FootballFieldBox(
                 strokeWidth = 3f
             )
         }
-        Box(
-            modifier = Modifier
-                .width(boxSize.first.dp)
-                .height(boxSize.second.dp)
-        ) {
-            Spacer(
-                modifier = Modifier
-                    .offset(
-                        (boxSize.first * firstCircle.first).dp - 25.dp,
-                        (boxSize.second * firstCircle.second).dp
-                    )
-                    .size(50.dp)
-                    .clip(CircleShape)
-                    .background(Color.Cyan)
-                    .pointerInput(Unit) {
-                        detectDragGestures { change, dragAmount ->
-                            change.consume()
-                            val nextX =
-                                ((boxSize.first * firstCircle.first) + dragAmount.x) / boxSize.first
-                            val nextY =
-                                ((boxSize.second * firstCircle.second) + dragAmount.y) / boxSize.second
-                            firstCircle = Pair(nextX, nextY)
-                        }
-                    }
-            )
-        }
+
     }
 
 }

--- a/feature/match/src/main/java/com/eshc/goonersapp/feature/match/component/formation/FootballFieldBox.kt
+++ b/feature/match/src/main/java/com/eshc/goonersapp/feature/match/component/formation/FootballFieldBox.kt
@@ -1,0 +1,164 @@
+package com.eshc.goonersapp.feature.match.component.formation
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.eshc.goonersapp.core.designsystem.theme.BrushMainGradient
+import com.eshc.goonersapp.core.designsystem.theme.Color88FFFFFF
+
+@Composable
+fun FootballFieldBox(
+    modifier: Modifier = Modifier,
+    rotateDegree : Float = 0f
+) {
+    var firstCircle by remember { mutableStateOf(Pair(0.5f, 0.125f)) }
+    var boxSize by remember { mutableStateOf(Triple<Float, Float, Boolean>(0f, 0f, true)) }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(10.dp))
+            .background(BrushMainGradient)
+            .rotate(rotateDegree),
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(
+            modifier = modifier.onGloballyPositioned {
+                boxSize = Triple(
+                    it.size.width.toFloat(),
+                    it.size.height.toFloat(),
+                    boxSize.second > it.size.height.toFloat()
+                )
+            }
+        ) {
+            drawArc(
+                color = Color88FFFFFF,
+                startAngle = 0f,
+                sweepAngle = 180f,
+                useCenter = false,
+                style = Stroke(width = 3f),
+                size = Size(width = size.width * 0.3f, height = size.height * 0.3f),
+                topLeft = Offset(size.width * 0.35f, (size.height * 0.15f) * -1f)
+            )
+            drawLine(
+                color = Color88FFFFFF,
+                start = Offset(0f, 0f),
+                end = Offset(0f, size.height),
+                strokeWidth = 3f
+            )
+            drawLine(
+                color = Color88FFFFFF,
+                start = Offset(0f, size.height),
+                end = Offset(size.width, size.height),
+                strokeWidth = 3f
+            )
+            drawLine(
+                color = Color88FFFFFF,
+                start = Offset(size.width, size.height),
+                end = Offset(size.width, 0f),
+                strokeWidth = 3f
+            )
+            drawLine(
+                color = Color88FFFFFF,
+                start = Offset(size.width, 0f),
+                end = Offset(0f, 0f),
+                strokeWidth = 3f
+            )
+            drawLine(
+                color = Color88FFFFFF,
+                start = Offset(size.width * 0.3f, size.height),
+                end = Offset(size.width * 0.3f, size.height * 0.84f),
+                strokeWidth = 3f
+            )
+            drawLine(
+                color = Color88FFFFFF,
+                start = Offset(size.width * 0.3f, size.height * 0.84f),
+                end = Offset(size.width * 0.7f, size.height * 0.84f),
+                strokeWidth = 3f
+            )
+            drawLine(
+                color = Color88FFFFFF,
+                start = Offset(size.width * 0.7f, size.height * 0.84f),
+                end = Offset(size.width * 0.7f, size.height),
+                strokeWidth = 3f
+            )
+            drawLine(
+                color = Color88FFFFFF,
+                start = Offset(size.width * 0.4f, size.height),
+                end = Offset(size.width * 0.4f, size.height * 0.9f),
+                strokeWidth = 3f
+            )
+            drawLine(
+                color = Color88FFFFFF,
+                start = Offset(size.width * 0.4f, size.height * 0.9f),
+                end = Offset(size.width * 0.6f, size.height * 0.9f),
+                strokeWidth = 3f
+            )
+            drawLine(
+                color = Color88FFFFFF,
+                start = Offset(size.width * 0.6f, size.height * 0.9f),
+                end = Offset(size.width * 0.6f, size.height),
+                strokeWidth = 3f
+            )
+        }
+        Box(
+            modifier = Modifier
+                .width(boxSize.first.dp)
+                .height(boxSize.second.dp)
+        ) {
+            Spacer(
+                modifier = Modifier
+                    .offset(
+                        (boxSize.first * firstCircle.first).dp - 25.dp,
+                        (boxSize.second * firstCircle.second).dp
+                    )
+                    .size(50.dp)
+                    .clip(CircleShape)
+                    .background(Color.Cyan)
+                    .pointerInput(Unit) {
+                        detectDragGestures { change, dragAmount ->
+                            change.consume()
+                            val nextX =
+                                ((boxSize.first * firstCircle.first) + dragAmount.x) / boxSize.first
+                            val nextY =
+                                ((boxSize.second * firstCircle.second) + dragAmount.y) / boxSize.second
+                            firstCircle = Pair(nextX, nextY)
+                        }
+                    }
+            )
+        }
+    }
+
+}
+
+@Preview
+@Composable
+fun PreviewFormationBox(){
+    FootballFieldBox()
+}

--- a/feature/match/src/main/java/com/eshc/goonersapp/feature/match/component/formation/LineUpPlayerCard.kt
+++ b/feature/match/src/main/java/com/eshc/goonersapp/feature/match/component/formation/LineUpPlayerCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
@@ -50,11 +51,12 @@ fun LineUpPlayerCard(
             )
         }
         Text(
-            modifier = Modifier.padding(top = 2.dp),
+            modifier = Modifier.padding(top = 2.dp).height(24.dp),
             text = player.displayName,
             style = GnrTypography.descriptionMedium.copy(
                 lineHeight = 11.sp
             ),
+            maxLines = 2,
             textAlign = TextAlign.Center,
             color = ColorFFDCDCDC
 

--- a/feature/match/src/main/java/com/eshc/goonersapp/feature/match/component/formation/LineUpPlayerCard.kt
+++ b/feature/match/src/main/java/com/eshc/goonersapp/feature/match/component/formation/LineUpPlayerCard.kt
@@ -1,0 +1,63 @@
+package com.eshc.goonersapp.feature.match.component.formation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFDCDCDC
+import com.eshc.goonersapp.core.designsystem.theme.GnrTypography
+import com.eshc.goonersapp.core.domain.model.player.Player
+
+@Composable
+fun LineUpPlayerCard(
+    player: Player,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.wrapContentWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .size(50.dp)
+                .clip(CircleShape)
+                .background(ColorFFDCDCDC)
+
+        ) {
+            AsyncImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f)
+                    .align(Alignment.Center),
+                contentScale = ContentScale.Crop,
+                model = player.imageUrl,
+                contentDescription = null
+            )
+        }
+        Text(
+            modifier = Modifier.padding(top = 2.dp),
+            text = player.displayName,
+            style = GnrTypography.descriptionMedium.copy(
+                lineHeight = 11.sp
+            ),
+            textAlign = TextAlign.Center,
+            color = ColorFFDCDCDC
+
+        )
+    }
+}

--- a/feature/match/src/main/java/com/eshc/goonersapp/feature/match/detail/MatchDetailScreen.kt
+++ b/feature/match/src/main/java/com/eshc/goonersapp/feature/match/detail/MatchDetailScreen.kt
@@ -239,11 +239,11 @@ fun MatchDetailScreen(
             item {
                 when (selectedTab) {
                     DetailTab.SUMMARY -> {
-
+                        SummaryScreen()
                     }
 
                     DetailTab.COMMENT -> {
-
+                        
                     }
                 }
             }

--- a/feature/match/src/main/java/com/eshc/goonersapp/feature/match/detail/SummaryScreen.kt
+++ b/feature/match/src/main/java/com/eshc/goonersapp/feature/match/detail/SummaryScreen.kt
@@ -1,0 +1,246 @@
+package com.eshc.goonersapp.feature.match.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.eshc.goonersapp.core.designsystem.theme.ColorFF10358A
+import com.eshc.goonersapp.core.designsystem.theme.ColorFF181818
+import com.eshc.goonersapp.core.designsystem.theme.ColorFF889AC4
+import com.eshc.goonersapp.core.designsystem.theme.ColorFFE6EDFC
+import com.eshc.goonersapp.core.designsystem.theme.GnrTypography
+import com.eshc.goonersapp.core.domain.model.player.Player
+import com.eshc.goonersapp.feature.match.component.formation.FootballFieldBox
+import com.eshc.goonersapp.feature.match.component.formation.LineUpPlayerCard
+
+@Composable
+fun SummaryScreen() {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+    ) {
+
+        Text(
+            text = "Line-Ups",
+            modifier = Modifier.padding(top = 30.dp, bottom = 16.dp),
+            style = GnrTypography.subtitleMedium,
+            color = ColorFF181818
+        )
+
+        Box(
+            modifier = Modifier
+                .width(IntrinsicSize.Max)
+                .height(IntrinsicSize.Max)
+        ) {
+            FootballFieldBox(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(0.9f, true),
+                rotateDegree = 180f
+            )
+            PlayerLineupBox()
+        }
+
+        Text(
+            text = "Player To Watch For",
+            modifier = Modifier.padding(top = 30.dp, bottom = 16.dp),
+            style = GnrTypography.subtitleMedium,
+            color = ColorFF181818
+        )
+        PlayerToWatchForBox(
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+
+}
+
+
+@Composable
+fun PlayerToWatchForBox(
+    modifier: Modifier = Modifier
+){
+    BoxWithConstraints(
+        modifier = modifier.background(
+            color = ColorFFE6EDFC,
+            shape = RoundedCornerShape(10.dp)
+        )
+    ){
+        val boxWidth = maxWidth.value
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier
+                    .padding(top = 10.dp, bottom = 8.dp)
+                    .offset(x = (boxWidth * 0.3f).dp)
+            ){
+                Text(
+                    text = "8",
+                    style = GnrTypography.heading2SemiBold,
+                    color = ColorFF889AC4
+                )
+                Column(
+                    modifier = Modifier.padding(start = 4.dp)
+                ) {
+                    Text(
+                        text = "Martin Ødegaard",
+                        style = GnrTypography.body1Medium,
+                        color = ColorFF10358A
+                    )
+                    Text(
+                        text = "Midfielder",
+                        style = GnrTypography.descriptionRegular,
+                        color = ColorFF10358A
+                    )
+                }
+            }
+
+        }
+    }
+}
+
+@Composable
+fun PlayerLineupBox(){
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 12.dp, end = 12.dp, top = 4.dp, bottom = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            horizontalArrangement = Arrangement.SpaceAround
+        ){
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Aaron Ramsdale",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            horizontalArrangement = Arrangement.SpaceAround
+        ){
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Emile Smith-Rowe",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Emile Smith-Rowe",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Emile Smith-Rowe",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Emile Smith-Rowe",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            horizontalArrangement = Arrangement.SpaceAround
+        ){
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Emile Smith-Rowe",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Emile Smith-Rowe",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Emile Smith-Rowe",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Emile Smith-Rowe",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            horizontalArrangement = Arrangement.SpaceAround
+        ){
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Emile Smith-Rowe",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            horizontalArrangement = Arrangement.SpaceAround
+        ){
+
+            LineUpPlayerCard(
+                player = Player(
+                    id = 1,
+                    name = "Emile Smith-Rowe",
+                    backNumber = 17,
+                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
+                )
+            )
+
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewPlayerToWatchForBox(){
+    PlayerToWatchForBox()
+}

--- a/feature/match/src/main/java/com/eshc/goonersapp/feature/match/detail/SummaryScreen.kt
+++ b/feature/match/src/main/java/com/eshc/goonersapp/feature/match/detail/SummaryScreen.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.eshc.goonersapp.core.designsystem.theme.Color88FFFFFF
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF10358A
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF181818
 import com.eshc.goonersapp.core.designsystem.theme.ColorFF889AC4
@@ -19,228 +21,192 @@ import com.eshc.goonersapp.feature.match.component.formation.FootballFieldBox
 import com.eshc.goonersapp.feature.match.component.formation.LineUpPlayerCard
 
 @Composable
-fun SummaryScreen() {
+fun SummaryScreen(
+    startingPlayers: List<List<Player>> = emptyList(),
+    playerToWatchFor : Player = Player(0)
+) {
     Column(
         modifier = Modifier
-            .padding(horizontal = 12.dp)
+            .padding(start = 14.dp,end = 14.dp ,top = 22.dp, bottom =  80.dp)
     ) {
 
         Text(
             text = "Line-Ups",
-            modifier = Modifier.padding(top = 30.dp, bottom = 16.dp),
+            modifier = Modifier.padding(bottom = 16.dp),
             style = GnrTypography.subtitleMedium,
             color = ColorFF181818
         )
 
-        Box(
-            modifier = Modifier
-                .width(IntrinsicSize.Max)
-                .height(IntrinsicSize.Max)
-        ) {
-            FootballFieldBox(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(0.9f, true),
-                rotateDegree = 180f
-            )
-            PlayerLineupBox()
-        }
+        LineUpBox(
+            startingPlayers = startingPlayers
+        )
 
         Text(
             text = "Player To Watch For",
-            modifier = Modifier.padding(top = 30.dp, bottom = 16.dp),
+            modifier = Modifier.padding(top = 70.dp, bottom = 16.dp),
             style = GnrTypography.subtitleMedium,
             color = ColorFF181818
         )
         PlayerToWatchForBox(
+            player = playerToWatchFor,
+            games = 0,
+            goals = 0,
             modifier = Modifier.fillMaxWidth()
         )
     }
 
+}
+
+@Composable
+fun LineUpBox(
+    startingPlayers : List<List<Player>>
+){
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Max)
+    ) {
+        FootballFieldBox(
+            modifier = Modifier.fillMaxSize(),
+            rotateDegree = 180f
+        )
+        PlayerLineUpBox(
+            startingPlayers = startingPlayers
+        )
+    }
 }
 
 
 @Composable
 fun PlayerToWatchForBox(
+    player: Player,
+    games : Int,
+    goals : Int,
     modifier: Modifier = Modifier
 ){
-    BoxWithConstraints(
+    Box(
         modifier = modifier.background(
             color = ColorFFE6EDFC,
             shape = RoundedCornerShape(10.dp)
         )
     ){
-        val boxWidth = maxWidth.value
         Column(
             modifier = Modifier.fillMaxWidth()
         ) {
             Row(
                 modifier = Modifier
-                    .padding(top = 10.dp, bottom = 8.dp)
-                    .offset(x = (boxWidth * 0.3f).dp)
+                    .padding(top = 10.dp, bottom = 8.dp, end = 12.dp)
             ){
                 Text(
-                    text = "8",
+                    modifier = Modifier
+                        .wrapContentHeight()
+                        .weight(0.45f)
+                        .padding(end = 18.dp),
+                    text = "${player.backNumber}",
                     style = GnrTypography.heading2SemiBold,
-                    color = ColorFF889AC4
+                    color = ColorFF889AC4,
+                    textAlign = TextAlign.End
                 )
                 Column(
-                    modifier = Modifier.padding(start = 4.dp)
+                    modifier = Modifier
+                        .wrapContentHeight()
+                        .weight(0.55f)
                 ) {
                     Text(
-                        text = "Martin Ødegaard",
+                        text = player.displayName,
                         style = GnrTypography.body1Medium,
                         color = ColorFF10358A
                     )
                     Text(
-                        text = "Midfielder",
+                        text = player.position,
                         style = GnrTypography.descriptionRegular,
                         color = ColorFF10358A
                     )
                 }
             }
-
+            PlayerStatToWatchForRow(
+                title = "Games",
+                stat = "$games",
+                modifier = Modifier.padding(bottom = 3.dp)
+            )
+            PlayerStatToWatchForRow(
+                title = "Goals",
+                stat = "$goals",
+                modifier = Modifier
+            )
         }
+        
+        AsyncImage(
+            modifier = Modifier.fillMaxWidth(0.35f),
+            model = "",
+            contentDescription = ""
+        )
     }
 }
 
 @Composable
-fun PlayerLineupBox(){
+fun PlayerStatToWatchForRow(
+    title : String,
+    stat : String,
+    modifier: Modifier = Modifier
+){
+    Row(
+        modifier = modifier
+            .background(color = Color88FFFFFF)
+            .padding(top = 10.dp, bottom = 8.dp, end = 12.dp)
+    ){
+        Spacer(
+            modifier = Modifier
+                .wrapContentHeight()
+                .weight(0.45f)
+        )
+        Text(
+            modifier = Modifier.wrapContentHeight().weight(0.45f),
+            text = title,
+            style = GnrTypography.body1Medium,
+            color = ColorFF181818
+        )
+        Text(
+            modifier = Modifier.wrapContentHeight().weight(0.1f),
+            text = stat,
+            maxLines = 1,
+            textAlign = TextAlign.Center,
+            style = GnrTypography.body1Medium,
+            color = ColorFF10358A
+        )
+    }
+}
+
+@Composable
+fun PlayerLineUpBox(
+    startingPlayers : List<List<Player>>
+){
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(start = 12.dp, end = 12.dp, top = 4.dp, bottom = 4.dp)
+            .padding(start = 12.dp, end = 12.dp, top = 16.dp, bottom = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(26.dp)
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            horizontalArrangement = Arrangement.SpaceAround
-        ){
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Aaron Ramsdale",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            horizontalArrangement = Arrangement.SpaceAround
-        ){
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Emile Smith-Rowe",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Emile Smith-Rowe",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Emile Smith-Rowe",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Emile Smith-Rowe",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            horizontalArrangement = Arrangement.SpaceAround
-        ){
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Emile Smith-Rowe",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Emile Smith-Rowe",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Emile Smith-Rowe",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Emile Smith-Rowe",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            horizontalArrangement = Arrangement.SpaceAround
-        ){
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Emile Smith-Rowe",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            horizontalArrangement = Arrangement.SpaceAround
-        ){
+        startingPlayers.forEach { players ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                horizontalArrangement = Arrangement.SpaceAround
+            ){
+                players.forEach {  player ->
+                    LineUpPlayerCard(
+                        player = player
+                    )
+                }
 
-            LineUpPlayerCard(
-                player = Player(
-                    id = 1,
-                    name = "Emile Smith-Rowe",
-                    backNumber = 17,
-                    imageUrl = "https://resources.premierleague.com/premierleague/photos/players/250x250/p85955.png"
-                )
-            )
-
+            }
         }
     }
 }
 
 @Preview
 @Composable
-fun PreviewPlayerToWatchForBox(){
-    PlayerToWatchForBox()
+fun PreviewSummaryScreen(){
+    SummaryScreen()
 }


### PR DESCRIPTION
## Description
 - 수정된 디자인에 따른 MatchDetailScreen UI 하단 부분 수정

### Content
 1. 라인업, 주목할만한 선수 UI 추가
 2. API 연동 후 데이터에 따라 수정이 있을 수도 있습니다.

## Result screenshot
<img width="280" src="https://github.com/eshc123/GoonersApp/assets/50227341/94d3ed95-be72-4871-851e-6f49e7400fa1">

## Comment
1. 라인업 관련 API 연동 작업은  add-match-detail-api, 남은 UI 및 추가로 변경된 디자인 적용 작업은 mod-match-screen (3)에서 이어서 진행하도록 하겠습니다.