### PR TITLE
[FEATURE] ADD MatchLineup API

### DIFF
--- a/core/data/src/main/java/com/eshc/goonersapp/core/data/fake/FakeMatchRepositoryImpl.kt
+++ b/core/data/src/main/java/com/eshc/goonersapp/core/data/fake/FakeMatchRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.eshc.goonersapp.core.domain.model.DataResult
 import com.eshc.goonersapp.core.domain.model.match.Match
 import com.eshc.goonersapp.core.domain.model.match.MatchData
 import com.eshc.goonersapp.core.domain.model.match.MatchInformation
+import com.eshc.goonersapp.core.domain.model.match.MatchLineup
 import com.eshc.goonersapp.core.domain.repository.MatchRepository
 import com.eshc.goonersapp.core.network.fake.FakeMatchDataSource
 import kotlinx.coroutines.flow.Flow
@@ -58,6 +59,14 @@ class FakeMatchRepositoryImpl @Inject constructor(
     override fun getRecentlyMatch(): Flow<DataResult<MatchData>> = flow {
         val result = fakeMatchDataSource
             .getRecentlyMatch()
+            .toDataResult { remote -> remote.toModel() }
+
+        emit(result)
+    }
+
+    override fun getMatchLineup(matchId: Int): Flow<DataResult<MatchLineup>> = flow {
+        val result = fakeMatchDataSource
+            .getMatchLineup(matchId)
             .toDataResult { remote -> remote.toModel() }
 
         emit(result)

--- a/core/data/src/main/java/com/eshc/goonersapp/core/data/mapper/MatchMapper.kt
+++ b/core/data/src/main/java/com/eshc/goonersapp/core/data/mapper/MatchMapper.kt
@@ -1,17 +1,22 @@
 package com.eshc.goonersapp.core.data.mapper
 
-import com.eshc.goonersapp.core.domain.model.match.LineUp
+import com.eshc.goonersapp.core.domain.model.match.PlayerLineup
 import com.eshc.goonersapp.core.domain.model.match.Match
 import com.eshc.goonersapp.core.domain.model.match.MatchData
 import com.eshc.goonersapp.core.domain.model.match.MatchDetail
 import com.eshc.goonersapp.core.domain.model.match.MatchInformation
+import com.eshc.goonersapp.core.domain.model.match.MatchLineup
 import com.eshc.goonersapp.core.domain.model.match.NotablePlayer
 import com.eshc.goonersapp.core.domain.model.match.Performance
+import com.eshc.goonersapp.core.domain.model.match.TeamLineup
 import com.eshc.goonersapp.core.domain.model.match.toMatchDetailType
 import com.eshc.goonersapp.core.network.model.match.RemoteMatch
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchData
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchDetail
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchInformation
+import com.eshc.goonersapp.core.network.model.match.RemoteMatchLineup
+import com.eshc.goonersapp.core.network.model.match.RemotePlayerLineup
+import com.eshc.goonersapp.core.network.model.match.RemoteTeamLineup
 
 /**
  * [RemoteMatch] Mapper
@@ -86,4 +91,34 @@ fun RemoteMatchDetail.toModel() = MatchDetail(
 fun RemoteMatchData.toModel() = MatchData(
     match = match.toModel(),
     matchDetail = matchDetail.map { remote -> remote.toModel() }
+)
+
+/**
+ * [RemoteMatchLineup] Mapper
+ *  - Mapper [RemoteMatchLineup] to [MatchLineup]
+ */
+fun RemoteMatchLineup.toModel() = MatchLineup(
+    homeLineup = homeLineup.toModel(),
+    awayLineup = awayLineup.toModel()
+)
+
+fun RemoteTeamLineup.toModel() = TeamLineup(
+    teamId = teamId.toInt(),
+    formation = formation,
+    playerLineup = players.map { remote -> remote.toModel() }
+)
+
+fun RemotePlayerLineup.toModel() = PlayerLineup(
+    lineUpId = lineUpId,
+    matchId = matchId,
+    playerId = playerId,
+    teamId = teamId,
+    playerName = playerName,
+    playerImageUrl = playerImageUrl,
+    playerBackNumber = jerseyNumber,
+    formationField = formationField,
+    formationPosition = formationPosition,
+    positionId = positionId,
+    positionCategory = positionCategory,
+    positionInitial = positionInitial
 )

--- a/core/data/src/main/java/com/eshc/goonersapp/core/data/mapper/MatchMapper.kt
+++ b/core/data/src/main/java/com/eshc/goonersapp/core/data/mapper/MatchMapper.kt
@@ -54,21 +54,6 @@ fun RemoteMatchInformation.toModel() = MatchInformation(
             playerGoalCount = remote.goalCount
         )
     },
-    lineUp = lineUp.map { remote ->
-        LineUp(
-            lineUpId = remote.lineUpId,
-            matchId = remote.matchId,
-            playerId = remote.playerId,
-            teamId = remote.teamId,
-            playerName = remote.playerName,
-            playerBackNumber = remote.jerseyNumber,
-            formationField = remote.formationField,
-            formationPosition = remote.formationPosition,
-            positionId = remote.positionId,
-            positionCategory = remote.positionCategory,
-            positionInitial = remote.positionInitial
-        )
-    },
     performance = Performance(
         opponentImageUrl = performance.opponentImage,
         win = performance.win,

--- a/core/data/src/main/java/com/eshc/goonersapp/core/data/repository/MatchRepositoryImpl.kt
+++ b/core/data/src/main/java/com/eshc/goonersapp/core/data/repository/MatchRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.eshc.goonersapp.core.domain.model.DataResult
 import com.eshc.goonersapp.core.domain.model.match.Match
 import com.eshc.goonersapp.core.domain.model.match.MatchData
 import com.eshc.goonersapp.core.domain.model.match.MatchInformation
+import com.eshc.goonersapp.core.domain.model.match.MatchLineup
 import com.eshc.goonersapp.core.domain.repository.MatchRepository
 import com.eshc.goonersapp.core.network.MatchNetworkDataSource
 import kotlinx.coroutines.flow.Flow
@@ -55,6 +56,14 @@ class MatchRepositoryImpl @Inject constructor(
     override fun getRecentlyMatch(): Flow<DataResult<MatchData>> = flow {
         val result = matchNetworkDataSource
             .getRecentlyMatch()
+            .toDataResult { remote -> remote.toModel() }
+
+        emit(result)
+    }
+
+    override fun getMatchLineup(matchId: Int): Flow<DataResult<MatchLineup>> = flow {
+        val result = matchNetworkDataSource
+            .getMatchLineup(matchId)
             .toDataResult { remote -> remote.toModel() }
 
         emit(result)

--- a/core/data/src/test/java/com/eshc/goonersapp/core/data/FakeMatchTest.kt
+++ b/core/data/src/test/java/com/eshc/goonersapp/core/data/FakeMatchTest.kt
@@ -5,7 +5,9 @@ import com.eshc.goonersapp.core.domain.model.DataResult
 import com.eshc.goonersapp.core.domain.model.match.Match
 import com.eshc.goonersapp.core.domain.model.match.MatchData
 import com.eshc.goonersapp.core.domain.model.match.MatchInformation
+import com.eshc.goonersapp.core.domain.model.match.MatchLineup
 import com.eshc.goonersapp.core.domain.model.match.Performance
+import com.eshc.goonersapp.core.domain.model.match.TeamLineup
 import com.eshc.goonersapp.core.domain.repository.MatchRepository
 import com.eshc.goonersapp.core.network.fake.FakeMatchDataSource
 import kotlinx.coroutines.runBlocking
@@ -62,7 +64,6 @@ class FakeMatchTest {
                     assertEquals(
                         MatchInformation(
                             notablePlayer = null,
-                            lineUp = listOf(),
                             performance = Performance(opponentImageUrl = "", win = 0, draw = 0, lose = 0)
                         ),
                         result.data
@@ -102,6 +103,32 @@ class FakeMatchTest {
                         MatchData(
                             match = Match(),
                             matchDetail = listOf()
+                        ),
+                        result.data
+                    )
+                }
+                is DataResult.Failure -> { /* Nothing */ }
+            }
+        }
+    }
+
+    @Test
+    fun testMatchLineupWithFake() = runBlocking {
+        fakeMatchRepository.getMatchLineup(38).collect { result ->
+            when (result) {
+                is DataResult.Success -> {
+                    assertEquals(
+                        MatchLineup(
+                            homeLineup = TeamLineup(
+                                teamId = 0,
+                                formation = "",
+                                playerLineup = emptyList()
+                            ),
+                            awayLineup = TeamLineup(
+                                teamId = 0,
+                                formation = "",
+                                playerLineup = emptyList()
+                            )
                         ),
                         result.data
                     )

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/match/MatchInformation.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/match/MatchInformation.kt
@@ -2,7 +2,6 @@ package com.eshc.goonersapp.core.domain.model.match
 
 data class MatchInformation(
     val notablePlayer: NotablePlayer? = null,
-    val lineUp: List<LineUp>,
     val performance: Performance
 )
 

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/match/MatchInformation.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/match/MatchInformation.kt
@@ -16,20 +16,6 @@ data class NotablePlayer(
     val playerGoalCount: Int
 )
 
-data class LineUp(
-    val lineUpId: Double,
-    val matchId: Int,
-    val playerId: Int,
-    val teamId: Int,
-    val playerName: String,
-    val playerBackNumber: Int,
-    val formationField: String?,
-    val formationPosition: Int?,
-    val positionId: Int,
-    val positionCategory: String,
-    val positionInitial: String
-)
-
 data class Performance(
     val opponentImageUrl: String,
     val win: Int,

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/match/MatchLineup.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/match/MatchLineup.kt
@@ -1,0 +1,27 @@
+package com.eshc.goonersapp.core.domain.model.match
+
+data class MatchLineup(
+    val homeLineup : TeamLineup,
+    val awayLineup : TeamLineup
+)
+
+data class TeamLineup(
+    val teamId : Int,
+    val formation : String,
+    val playerLineup : List<PlayerLineup>
+)
+
+data class PlayerLineup(
+    val lineUpId: Long,
+    val matchId: Int,
+    val playerId: Int,
+    val teamId: Int,
+    val playerName: String,
+    val playerImageUrl : String,
+    val playerBackNumber: Int,
+    val formationField: String?,
+    val formationPosition: Int?,
+    val positionId: Int,
+    val positionCategory: String,
+    val positionInitial: String
+)

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/repository/MatchRepository.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/repository/MatchRepository.kt
@@ -4,6 +4,7 @@ import com.eshc.goonersapp.core.domain.model.DataResult
 import com.eshc.goonersapp.core.domain.model.match.Match
 import com.eshc.goonersapp.core.domain.model.match.MatchData
 import com.eshc.goonersapp.core.domain.model.match.MatchInformation
+import com.eshc.goonersapp.core.domain.model.match.MatchLineup
 import kotlinx.coroutines.flow.Flow
 
 interface MatchRepository {
@@ -18,4 +19,5 @@ interface MatchRepository {
 
     fun getRecentlyMatch() : Flow<DataResult<MatchData>>
 
+    fun getMatchLineup(matchId: Int) : Flow<DataResult<MatchLineup>>
 }

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/usecase/match/GetMatchLineupUseCase.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/usecase/match/GetMatchLineupUseCase.kt
@@ -1,0 +1,17 @@
+package com.eshc.goonersapp.core.domain.usecase.match
+
+import com.eshc.goonersapp.core.domain.model.DataResult
+import com.eshc.goonersapp.core.domain.model.match.MatchLineup
+import com.eshc.goonersapp.core.domain.repository.MatchRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetMatchLineupUseCase @Inject constructor(
+    private val matchRepository: MatchRepository
+) {
+    operator fun invoke(
+        matchId: Int,
+    ): Flow<DataResult<MatchLineup>> = matchRepository.getMatchLineup(
+        matchId
+    )
+}

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/MatchNetworkDataSource.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/MatchNetworkDataSource.kt
@@ -4,6 +4,7 @@ import com.eshc.goonersapp.core.network.model.NetworkResult
 import com.eshc.goonersapp.core.network.model.match.RemoteMatch
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchData
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchInformation
+import com.eshc.goonersapp.core.network.model.match.RemoteMatchLineup
 
 interface MatchNetworkDataSource {
 
@@ -20,4 +21,6 @@ interface MatchNetworkDataSource {
     suspend fun getUpcomingMatches(): NetworkResult<List<RemoteMatch>>
 
     suspend fun getRecentlyMatch(): NetworkResult<RemoteMatchData>
+
+    suspend fun getMatchLineup(matchId: Int) : NetworkResult<RemoteMatchLineup>
 }

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/api/MatchNetworkService.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/api/MatchNetworkService.kt
@@ -4,6 +4,7 @@ import com.eshc.goonersapp.core.network.model.BaseResponse
 import com.eshc.goonersapp.core.network.model.match.RemoteMatch
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchData
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchInformation
+import com.eshc.goonersapp.core.network.model.match.RemoteMatchLineup
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -40,4 +41,9 @@ interface MatchNetworkService {
     suspend fun getRecentlyMatch(
         @Query("teamId") teamId : Int = 19
     ) : Response<BaseResponse<RemoteMatchData>>
+
+    @GET(value = "$MATCH_BASE_URL/lineup")
+    suspend fun getMatchLineup(
+        @Query("matchId") matchId: Int
+    ) : Response<BaseResponse<RemoteMatchLineup>>
 }

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakeMatchDataSource.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakeMatchDataSource.kt
@@ -6,6 +6,8 @@ import com.eshc.goonersapp.core.network.model.match.Performance
 import com.eshc.goonersapp.core.network.model.match.RemoteMatch
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchData
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchInformation
+import com.eshc.goonersapp.core.network.model.match.RemoteMatchLineup
+import com.eshc.goonersapp.core.network.model.match.RemoteTeamLineup
 import javax.inject.Inject
 
 /**
@@ -31,6 +33,10 @@ import javax.inject.Inject
  *
  *  getRecentlyMatch()
  *   - return [NetworkResult.Success]
+ *
+ *  getMatchLineup(matchId: Int)
+ *   - if matchId is over 39 then return [NetworkResult.Error]
+ *   - else return [NetworkResult.Success]
  */
 class FakeMatchDataSource @Inject constructor(): MatchNetworkDataSource {
     override suspend fun getMatch(matchId: Int): NetworkResult<RemoteMatchData> {
@@ -88,4 +94,16 @@ class FakeMatchDataSource @Inject constructor(): MatchNetworkDataSource {
         )
     }
 
+    override suspend fun getMatchLineup(matchId: Int): NetworkResult<RemoteMatchLineup> {
+        return if (matchId < 39) {
+            NetworkResult.Success(
+                RemoteMatchLineup(
+                    homeLineup = RemoteTeamLineup(),
+                    awayLineup = RemoteTeamLineup()
+                )
+            )
+        } else {
+            NetworkResult.Error(code = 404, message = "Not Found")
+        }
+    }
 }

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakeMatchDataSource.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakeMatchDataSource.kt
@@ -57,7 +57,6 @@ class FakeMatchDataSource @Inject constructor(): MatchNetworkDataSource {
             NetworkResult.Success(
                 RemoteMatchInformation(
                     notablePlayer = null,
-                    lineUp = listOf(),
                     performance = Performance()
                 )
             )

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/model/match/RemoteMatchInformation.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/model/match/RemoteMatchInformation.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RemoteMatchInformation(
     @SerialName("notablePlayer") val notablePlayer: NotablePlayer? = null,
-    @SerialName("lineUp") val lineUp: List<LineUp>,
     @SerialName("performance") val performance: Performance
 )
 

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/model/match/RemoteMatchInformation.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/model/match/RemoteMatchInformation.kt
@@ -22,22 +22,6 @@ data class NotablePlayer(
 )
 
 @Serializable
-data class LineUp(
-    @SerialName("lineup_id") val lineUpId: Double = 0.0,
-    @SerialName("match_id") val matchId: Int = 0,
-    @SerialName("player_id") val playerId: Int = 0,
-    @SerialName("team_id") val teamId: Int = 0,
-    @SerialName("player_name") val playerName: String = "",
-    @SerialName("player_image_url") val playerImageUrl: String = "",
-    @SerialName("jersey_number") val jerseyNumber: Int = 0,
-    @SerialName("formation_field") val formationField: String? = "",
-    @SerialName("formation_position") val formationPosition: Int? = 0,
-    @SerialName("position_id") val positionId: Int = 0,
-    @SerialName("position_category") val positionCategory: String = "",
-    @SerialName("position_initial") val positionInitial: String = ""
-)
-
-@Serializable
 data class Performance(
     @SerialName("opponent_image_url") val opponentImage: String = "",
     @SerialName("WIN") val win: Int = 0,

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/model/match/RemoteMatchLineup.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/model/match/RemoteMatchLineup.kt
@@ -3,6 +3,7 @@ package com.eshc.goonersapp.core.network.model.match
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@Serializable
 data class RemoteMatchLineup(
     @SerialName("home_lineup") val homeLineup : RemoteTeamLineup = RemoteTeamLineup(),
     @SerialName("away_lineup") val awayLineup : RemoteTeamLineup = RemoteTeamLineup(),
@@ -11,7 +12,7 @@ data class RemoteMatchLineup(
 @Serializable
 data class RemoteTeamLineup(
     @SerialName("team_id") val teamId : Long = 0L,
-    @SerialName("formaition") val formation : String = "",
+    @SerialName("formation") val formation : String = "",
     @SerialName("players") val players : List<PlayerLineup> = emptyList()
 )
 

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/model/match/RemoteMatchLineup.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/model/match/RemoteMatchLineup.kt
@@ -13,11 +13,11 @@ data class RemoteMatchLineup(
 data class RemoteTeamLineup(
     @SerialName("team_id") val teamId : Long = 0L,
     @SerialName("formation") val formation : String = "",
-    @SerialName("players") val players : List<PlayerLineup> = emptyList()
+    @SerialName("players") val players : List<RemotePlayerLineup> = emptyList()
 )
 
 @Serializable
-data class PlayerLineup(
+data class RemotePlayerLineup(
     @SerialName("lineup_id") val lineUpId: Long = 0L,
     @SerialName("match_id") val matchId: Int = 0,
     @SerialName("player_id") val playerId: Int = 0,

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/model/match/RemoteMatchLineup.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/model/match/RemoteMatchLineup.kt
@@ -1,0 +1,32 @@
+package com.eshc.goonersapp.core.network.model.match
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+data class RemoteMatchLineup(
+    @SerialName("home_lineup") val homeLineup : RemoteTeamLineup = RemoteTeamLineup(),
+    @SerialName("away_lineup") val awayLineup : RemoteTeamLineup = RemoteTeamLineup(),
+)
+
+@Serializable
+data class RemoteTeamLineup(
+    @SerialName("team_id") val teamId : Long = 0L,
+    @SerialName("formaition") val formation : String = "",
+    @SerialName("players") val players : List<PlayerLineup> = emptyList()
+)
+
+@Serializable
+data class PlayerLineup(
+    @SerialName("lineup_id") val lineUpId: Long = 0L,
+    @SerialName("match_id") val matchId: Int = 0,
+    @SerialName("player_id") val playerId: Int = 0,
+    @SerialName("team_id") val teamId: Int = 0,
+    @SerialName("player_name") val playerName: String = "",
+    @SerialName("player_image_url") val playerImageUrl: String = "",
+    @SerialName("jersey_number") val jerseyNumber: Int = 0,
+    @SerialName("formation_field") val formationField: String? = "",
+    @SerialName("formation_position") val formationPosition: Int? = 0,
+    @SerialName("position_id") val positionId: Int = 0,
+    @SerialName("position_category") val positionCategory: String = "",
+    @SerialName("position_initial") val positionInitial: String = ""
+)

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/remote/MatchNetworkDataSourceImpl.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/remote/MatchNetworkDataSourceImpl.kt
@@ -7,6 +7,7 @@ import com.eshc.goonersapp.core.network.model.handleApi
 import com.eshc.goonersapp.core.network.model.match.RemoteMatch
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchData
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchInformation
+import com.eshc.goonersapp.core.network.model.match.RemoteMatchLineup
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -49,6 +50,12 @@ class MatchNetworkDataSourceImpl @Inject constructor(
     override suspend fun getRecentlyMatch(): NetworkResult<RemoteMatchData> {
         return handleApi {
             matchNetworkService.getRecentlyMatch()
+        }
+    }
+
+    override suspend fun getMatchLineup(matchId: Int): NetworkResult<RemoteMatchLineup> {
+        return handleApi {
+            matchNetworkService.getMatchLineup(matchId)
         }
     }
 }

--- a/core/network/src/test/java/com/eshc/goonersapp/core/network/FakeMatchDataSourceTest.kt
+++ b/core/network/src/test/java/com/eshc/goonersapp/core/network/FakeMatchDataSourceTest.kt
@@ -5,6 +5,7 @@ import com.eshc.goonersapp.core.network.model.NetworkResult
 import com.eshc.goonersapp.core.network.model.match.Performance
 import com.eshc.goonersapp.core.network.model.match.RemoteMatch
 import com.eshc.goonersapp.core.network.model.match.RemoteMatchDetail
+import com.eshc.goonersapp.core.network.model.match.RemoteMatchLineup
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -106,6 +107,21 @@ class FakeMatchDataSourceTest {
                 assertEquals(
                     listOf<RemoteMatchDetail>(),
                     result.data.matchDetail
+                )
+            }
+            is NetworkResult.Error -> { /* Nothing */ }
+            is NetworkResult.Exception -> { /* Nothing */ }
+        }
+
+    }
+
+    @Test
+    fun fakeGetMatchLineup() = runBlocking {
+        when (val result = fakeMatchDataSource.getMatchLineup(38)) {
+            is NetworkResult.Success -> {
+                assertEquals(
+                    RemoteMatchLineup(),
+                    result.data
                 )
             }
             is NetworkResult.Error -> { /* Nothing */ }

--- a/core/network/src/test/java/com/eshc/goonersapp/core/network/FakeMatchDataSourceTest.kt
+++ b/core/network/src/test/java/com/eshc/goonersapp/core/network/FakeMatchDataSourceTest.kt
@@ -2,9 +2,9 @@ package com.eshc.goonersapp.core.network
 
 import com.eshc.goonersapp.core.network.fake.FakeMatchDataSource
 import com.eshc.goonersapp.core.network.model.NetworkResult
-import com.eshc.goonersapp.core.network.model.match.LineUp
-import com.eshc.goonersapp.core.network.model.match.RemoteMatchDetail
+import com.eshc.goonersapp.core.network.model.match.Performance
 import com.eshc.goonersapp.core.network.model.match.RemoteMatch
+import com.eshc.goonersapp.core.network.model.match.RemoteMatchDetail
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -52,8 +52,8 @@ class FakeMatchDataSourceTest {
         when (result) {
             is NetworkResult.Success -> {
                 assertEquals(
-                    listOf<LineUp>(),
-                    result.data.lineUp
+                    Performance(),
+                    result.data.performance
                 )
             }
             is NetworkResult.Error -> {

--- a/core/network/src/test/java/com/eshc/goonersapp/core/network/RemoteMatchApiTest.kt
+++ b/core/network/src/test/java/com/eshc/goonersapp/core/network/RemoteMatchApiTest.kt
@@ -117,4 +117,16 @@ class RemoteMatchApiTest {
         val response = matchApi.getRecentlyMatch()
         assertEquals(responseOkCode, response.code())
     }
+
+    /**
+     * (Test Passed)
+     *
+     * Match Lineup network communication test
+     *  - when response code is 200, Test Passed
+     */
+    @Test
+    fun test_GET_LINEUP_STATUS_IS_OK() = runBlocking {
+        val response = matchApi.getMatchLineup(18138603)
+        assertEquals(responseOkCode, response.code())
+    }
 }


### PR DESCRIPTION
## Description
- 기존에 /match/information 포함되어있었던 lineup 이 분리되어 신규 API로 추가되어 그에 따른 API 추가 작업 진행하였습니다.
- MatchInformation에서는 Lineup 관련하여 삭제하였습니다.

### Content
 1. Network, Data, Domain 모듈에 getMatchLineup 관련 로직 추가하였고, Fake 및 Test Code 작성하였습니다.(UseCase는 제외)