### PR TITLE
[FEATURE] ADD Season Repository, UseCases

### DIFF
--- a/core/data/src/main/java/com/eshc/goonersapp/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/eshc/goonersapp/core/data/di/DataModule.kt
@@ -3,6 +3,7 @@ package com.eshc.goonersapp.core.data.di
 import com.eshc.goonersapp.core.data.repository.ChatRepositoryImpl
 import com.eshc.goonersapp.core.data.repository.MatchRepositoryImpl
 import com.eshc.goonersapp.core.data.repository.PlayerRepositoryImpl
+import com.eshc.goonersapp.core.data.repository.SeasonRepositoryImpl
 import com.eshc.goonersapp.core.data.repository.TeamRepositoryImpl
 import com.eshc.goonersapp.core.data.repository.UserRepositoryImpl
 import com.eshc.goonersapp.core.data.util.NetworkConnectivityManager
@@ -10,6 +11,7 @@ import com.eshc.goonersapp.core.data.util.NetworkConnectivityManagerImpl
 import com.eshc.goonersapp.core.domain.repository.ChatRepository
 import com.eshc.goonersapp.core.domain.repository.MatchRepository
 import com.eshc.goonersapp.core.domain.repository.PlayerRepository
+import com.eshc.goonersapp.core.domain.repository.SeasonRepository
 import com.eshc.goonersapp.core.domain.repository.TeamRepository
 import com.eshc.goonersapp.core.domain.repository.UserRepository
 import dagger.Binds
@@ -40,6 +42,11 @@ abstract class DataModule {
     abstract fun bindsTeamRepository(
         teamRepository: TeamRepositoryImpl,
     ): TeamRepository
+
+    @Binds
+    abstract fun bindsSeasonRepository(
+        seasonRepository: SeasonRepositoryImpl
+    ): SeasonRepository
 
     @Binds
     abstract fun bindsUserRepository(

--- a/core/data/src/main/java/com/eshc/goonersapp/core/data/fake/FakeSeasonRepositoryImpl.kt
+++ b/core/data/src/main/java/com/eshc/goonersapp/core/data/fake/FakeSeasonRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package com.eshc.goonersapp.core.data.fake
+
+import com.eshc.goonersapp.core.data.mapper.toDataResult
+import com.eshc.goonersapp.core.data.mapper.toModel
+import com.eshc.goonersapp.core.domain.model.DataResult
+import com.eshc.goonersapp.core.domain.model.season.League
+import com.eshc.goonersapp.core.domain.model.season.Rank
+import com.eshc.goonersapp.core.domain.model.season.Season
+import com.eshc.goonersapp.core.domain.repository.SeasonRepository
+import com.eshc.goonersapp.core.network.fake.FakeSeasonDataSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class FakeSeasonRepositoryImpl @Inject constructor(
+    private val fakeSeasonDataSource: FakeSeasonDataSource
+): SeasonRepository {
+    override fun getSeasonListByTeam(teamId: Int): Flow<DataResult<List<Season>>> = flow {
+        val result = fakeSeasonDataSource
+            .getSeasonListByTeam(teamId)
+            .toDataResult { remote -> remote.map { it.toModel() } }
+
+        emit(result)
+    }
+
+    override fun getLeagueListAsCurrentSeasonByTeam(
+        teamId: Int
+    ): Flow<DataResult<List<League>>> = flow {
+        val result = fakeSeasonDataSource
+            .getLeagueListAsCurrentSeasonByTeam(teamId)
+            .toDataResult { remote -> remote.map { it.toModel() } }
+
+        emit(result)
+    }
+
+    override fun getPreviewRankListByTeamAndSeason(
+        teamId: Int,
+        seasonId: Int,
+    ): Flow<DataResult<List<Rank>>> = flow {
+        val result = fakeSeasonDataSource
+            .getPreviewRankListByTeamAndSeason(teamId, seasonId)
+            .toDataResult { remote -> remote.map { it.toModel() } }
+
+        emit(result)
+    }
+
+}

--- a/core/data/src/main/java/com/eshc/goonersapp/core/data/mapper/SeasonMapper.kt
+++ b/core/data/src/main/java/com/eshc/goonersapp/core/data/mapper/SeasonMapper.kt
@@ -1,0 +1,33 @@
+package com.eshc.goonersapp.core.data.mapper
+
+import com.eshc.goonersapp.core.domain.model.season.League
+import com.eshc.goonersapp.core.domain.model.season.Rank
+import com.eshc.goonersapp.core.domain.model.season.Season
+import com.eshc.goonersapp.core.network.model.season.RemoteLeague
+import com.eshc.goonersapp.core.network.model.season.RemoteRank
+import com.eshc.goonersapp.core.network.model.season.RemoteSeason
+
+fun RemoteLeague.toModel() = League(
+    leagueId = leagueId,
+    leagueName = leagueName,
+    shortCode = shortCode,
+    leagueImgUrl = leagueImageUrl,
+    seasonId = seasonId,
+    season = season,
+    teamId = teamId
+)
+
+fun RemoteSeason.toModel() = Season(seasonId = seasonId, season = season)
+
+fun RemoteRank.toModel() = Rank(
+    standingId = standingId,
+    position = position,
+    points = points,
+    wins = win,
+    loss = loss,
+    draw = draw,
+    goalDifference = goalDifference,
+    teamId = teamId,
+    teamName = teamName,
+    shortCode = shortCode
+)

--- a/core/data/src/main/java/com/eshc/goonersapp/core/data/repository/SeasonRepositoryImpl.kt
+++ b/core/data/src/main/java/com/eshc/goonersapp/core/data/repository/SeasonRepositoryImpl.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class SeasonRepositoryImpl @Inject constructor(
     private val seasonNetworkDataSource: SeasonNetworkDataSource
 ): SeasonRepository {
-    override suspend fun getSeasonListByTeam(teamId: Int): Flow<DataResult<List<Season>>> = flow {
+    override fun getSeasonListByTeam(teamId: Int): Flow<DataResult<List<Season>>> = flow {
         val result = seasonNetworkDataSource
             .getSeasonListByTeam(teamId)
             .toDataResult { remote -> remote.map { it.toModel() } }
@@ -23,7 +23,7 @@ class SeasonRepositoryImpl @Inject constructor(
         emit(result)
     }
 
-    override suspend fun getLeagueListAsCurrentSeasonByTeam(
+    override fun getLeagueListAsCurrentSeasonByTeam(
         teamId: Int
     ): Flow<DataResult<List<League>>> = flow {
         val result = seasonNetworkDataSource
@@ -33,7 +33,7 @@ class SeasonRepositoryImpl @Inject constructor(
         emit(result)
     }
 
-    override suspend fun getPreviewRankListByTeamAndSeason(
+    override fun getPreviewRankListByTeamAndSeason(
         teamId: Int,
         seasonId: Int,
     ): Flow<DataResult<List<Rank>>> = flow {

--- a/core/data/src/main/java/com/eshc/goonersapp/core/data/repository/SeasonRepositoryImpl.kt
+++ b/core/data/src/main/java/com/eshc/goonersapp/core/data/repository/SeasonRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package com.eshc.goonersapp.core.data.repository
+
+import com.eshc.goonersapp.core.data.mapper.toDataResult
+import com.eshc.goonersapp.core.data.mapper.toModel
+import com.eshc.goonersapp.core.domain.model.DataResult
+import com.eshc.goonersapp.core.domain.model.season.League
+import com.eshc.goonersapp.core.domain.model.season.Rank
+import com.eshc.goonersapp.core.domain.model.season.Season
+import com.eshc.goonersapp.core.domain.repository.SeasonRepository
+import com.eshc.goonersapp.core.network.SeasonNetworkDataSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class SeasonRepositoryImpl @Inject constructor(
+    private val seasonNetworkDataSource: SeasonNetworkDataSource
+): SeasonRepository {
+    override suspend fun getSeasonListByTeam(teamId: Int): Flow<DataResult<List<Season>>> = flow {
+        val result = seasonNetworkDataSource
+            .getSeasonListByTeam(teamId)
+            .toDataResult { remote -> remote.map { it.toModel() } }
+
+        emit(result)
+    }
+
+    override suspend fun getLeagueListAsCurrentSeasonByTeam(
+        teamId: Int
+    ): Flow<DataResult<List<League>>> = flow {
+        val result = seasonNetworkDataSource
+            .getLeagueListAsCurrentSeasonByTeam(teamId)
+            .toDataResult { remote -> remote.map { it.toModel() } }
+
+        emit(result)
+    }
+
+    override suspend fun getPreviewRankListByTeamAndSeason(
+        teamId: Int,
+        seasonId: Int,
+    ): Flow<DataResult<List<Rank>>> = flow {
+        val result = seasonNetworkDataSource
+            .getPreviewRankListByTeamAndSeason(teamId, seasonId)
+            .toDataResult { remote -> remote.map { it.toModel() } }
+
+        emit(result)
+    }
+
+}

--- a/core/data/src/test/java/com/eshc/goonersapp/core/data/FakeMatchRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/eshc/goonersapp/core/data/FakeMatchRepositoryImplTest.kt
@@ -18,10 +18,10 @@ import org.junit.Test
 /**
  * Created By KanuKim97
  *
- * [FakeMatchTest]
+ * [FakeMatchRepositoryImplTest]
  *  - FakeMatchRepository Test
  */
-class FakeMatchTest {
+class FakeMatchRepositoryImplTest {
     private lateinit var fakeMatchDataSource: FakeMatchDataSource
     private lateinit var fakeMatchRepository: MatchRepository
 

--- a/core/data/src/test/java/com/eshc/goonersapp/core/data/FakeSeasonRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/eshc/goonersapp/core/data/FakeSeasonRepositoryImplTest.kt
@@ -1,0 +1,111 @@
+package com.eshc.goonersapp.core.data
+
+import com.eshc.goonersapp.core.data.fake.FakeSeasonRepositoryImpl
+import com.eshc.goonersapp.core.domain.model.DataResult
+import com.eshc.goonersapp.core.domain.model.season.Rank
+import com.eshc.goonersapp.core.domain.repository.SeasonRepository
+import com.eshc.goonersapp.core.network.fake.FakeSeasonDataSource
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Created By KanuKim97
+ *
+ * [FakeSeasonRepositoryImplTest]
+ *  - FakeSeasonRepository Test
+ */
+class FakeSeasonRepositoryImplTest {
+    private lateinit var fakeSeasonDataSource: FakeSeasonDataSource
+    private lateinit var fakeSeasonRepository: SeasonRepository
+
+    @Before
+    fun setUp() {
+        fakeSeasonDataSource = FakeSeasonDataSource()
+        fakeSeasonRepository = FakeSeasonRepositoryImpl(fakeSeasonDataSource)
+    }
+
+    @Test
+    fun fake_get_season_list_by_team_flow_collect_as_success() = runBlocking {
+        fakeSeasonRepository.getSeasonListByTeam(teamId = 19).collect { result ->
+            when (result) {
+                is DataResult.Success -> {
+                    assertEquals(
+                        "2023/2024",
+                        result.data.first().season
+                    )
+                }
+                is DataResult.Failure -> fail("Test should not be reached here")
+            }
+        }
+    }
+
+    @Test
+    fun fake_get_season_list_by_team_flow_collect_as_fail() = runBlocking {
+        fakeSeasonRepository.getSeasonListByTeam(teamId = 20).collect { result ->
+            when (result) {
+                is DataResult.Success -> fail("Test should not be reached here")
+                is DataResult.Failure -> assertEquals(404, result.code)
+            }
+        }
+    }
+
+    @Test
+    fun fake_get_league_list_as_current_season_by_team_as_success() = runBlocking {
+        fakeSeasonRepository.getLeagueListAsCurrentSeasonByTeam(19).collect { result ->
+            when(result) {
+                is DataResult.Success -> {
+                    assertEquals(
+                        21366,
+                        result.data.first().seasonId
+                    )
+                }
+                is DataResult.Failure -> fail("Test should not be reached here")
+            }
+        }
+    }
+
+
+    @Test
+    fun fake_get_league_list_as_current_season_by_team_as_fail() = runBlocking {
+        fakeSeasonRepository.getLeagueListAsCurrentSeasonByTeam(20).collect { result ->
+            when(result) {
+                is DataResult.Success -> fail("Test should not be reached here")
+                is DataResult.Failure -> assertEquals(404, result.code)
+            }
+        }
+    }
+
+    @Test
+    fun fake_get_preview_rank_list_by_team_and_season_as_success() = runBlocking {
+        fakeSeasonRepository.getPreviewRankListByTeamAndSeason(
+            teamId = 19,
+            seasonId = 21366
+        ).collect { result ->
+            when (result) {
+                is DataResult.Success -> {
+                    assertEquals(
+                        listOf<Rank>(),
+                        result.data
+                    )
+                }
+                is DataResult.Failure -> fail("Test should not be reached here")
+            }
+        }
+    }
+
+    @Test
+    fun fake_get_preview_rank_list_by_team_and_season_as_fail() = runBlocking {
+        fakeSeasonRepository.getPreviewRankListByTeamAndSeason(
+            teamId = 20,
+            seasonId = 21366
+        ).collect { result ->
+            when (result) {
+                is DataResult.Success -> fail("Test should not be reached here")
+                is DataResult.Failure -> assertEquals(404, result.code)
+            }
+        }
+    }
+}

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/season/League.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/season/League.kt
@@ -1,0 +1,11 @@
+package com.eshc.goonersapp.core.domain.model.season
+
+data class League(
+    val leagueId: Int,
+    val leagueName: String,
+    val shortCode: String,
+    val leagueImgUrl: String,
+    val seasonId: Int,
+    val season: String,
+    val teamId: Int
+)

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/season/Rank.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/season/Rank.kt
@@ -1,0 +1,14 @@
+package com.eshc.goonersapp.core.domain.model.season
+
+data class Rank(
+    val standingId: Int,
+    val position: Int,
+    val points: Int,
+    val wins: Int,
+    val loss: Int,
+    val draw: Int,
+    val goalDifference: Int,
+    val teamId: Int,
+    val teamName: String,
+    val shortCode: String
+)

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/season/Season.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/model/season/Season.kt
@@ -1,0 +1,3 @@
+package com.eshc.goonersapp.core.domain.model.season
+
+data class Season(val seasonId: Int, val season: String)

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/repository/SeasonRepository.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/repository/SeasonRepository.kt
@@ -1,0 +1,19 @@
+package com.eshc.goonersapp.core.domain.repository
+
+import com.eshc.goonersapp.core.domain.model.DataResult
+import com.eshc.goonersapp.core.domain.model.season.League
+import com.eshc.goonersapp.core.domain.model.season.Rank
+import com.eshc.goonersapp.core.domain.model.season.Season
+import kotlinx.coroutines.flow.Flow
+
+interface SeasonRepository {
+
+    suspend fun getSeasonListByTeam(teamId: Int): Flow<DataResult<List<Season>>>
+
+    suspend fun getLeagueListAsCurrentSeasonByTeam(teamId: Int): Flow<DataResult<List<League>>>
+
+    suspend fun getPreviewRankListByTeamAndSeason(
+        teamId: Int,
+        seasonId: Int
+    ): Flow<DataResult<List<Rank>>>
+}

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/repository/SeasonRepository.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/repository/SeasonRepository.kt
@@ -8,11 +8,11 @@ import kotlinx.coroutines.flow.Flow
 
 interface SeasonRepository {
 
-    suspend fun getSeasonListByTeam(teamId: Int): Flow<DataResult<List<Season>>>
+    fun getSeasonListByTeam(teamId: Int): Flow<DataResult<List<Season>>>
 
-    suspend fun getLeagueListAsCurrentSeasonByTeam(teamId: Int): Flow<DataResult<List<League>>>
+    fun getLeagueListAsCurrentSeasonByTeam(teamId: Int): Flow<DataResult<List<League>>>
 
-    suspend fun getPreviewRankListByTeamAndSeason(
+    fun getPreviewRankListByTeamAndSeason(
         teamId: Int,
         seasonId: Int
     ): Flow<DataResult<List<Rank>>>

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/usecase/season/GetLeagueListAsCurrentSeasonByTeamUseCase.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/usecase/season/GetLeagueListAsCurrentSeasonByTeamUseCase.kt
@@ -1,0 +1,15 @@
+package com.eshc.goonersapp.core.domain.usecase.season
+
+import com.eshc.goonersapp.core.domain.model.DataResult
+import com.eshc.goonersapp.core.domain.model.season.League
+import com.eshc.goonersapp.core.domain.repository.SeasonRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetLeagueListAsCurrentSeasonByTeamUseCase @Inject constructor(
+    private val seasonRepository: SeasonRepository
+) {
+    operator fun invoke(
+        teamId: Int
+    ): Flow<DataResult<List<League>>> = seasonRepository.getLeagueListAsCurrentSeasonByTeam(teamId)
+}

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/usecase/season/GetPreviewRankListByTeamAndSeasonUseCase.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/usecase/season/GetPreviewRankListByTeamAndSeasonUseCase.kt
@@ -1,0 +1,19 @@
+package com.eshc.goonersapp.core.domain.usecase.season
+
+import com.eshc.goonersapp.core.domain.model.DataResult
+import com.eshc.goonersapp.core.domain.model.season.Rank
+import com.eshc.goonersapp.core.domain.repository.SeasonRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetPreviewRankListByTeamAndSeasonUseCase @Inject constructor(
+    private val seasonRepository: SeasonRepository
+) {
+    operator fun invoke(
+        teamId: Int,
+        seasonId: Int
+    ): Flow<DataResult<List<Rank>>> = seasonRepository.getPreviewRankListByTeamAndSeason(
+        teamId = teamId,
+        seasonId = seasonId
+    )
+}

--- a/core/domain/src/main/java/com/eshc/goonersapp/core/domain/usecase/season/GetSeasonListByTeamUseCase.kt
+++ b/core/domain/src/main/java/com/eshc/goonersapp/core/domain/usecase/season/GetSeasonListByTeamUseCase.kt
@@ -1,0 +1,15 @@
+package com.eshc.goonersapp.core.domain.usecase.season
+
+import com.eshc.goonersapp.core.domain.model.DataResult
+import com.eshc.goonersapp.core.domain.model.season.Season
+import com.eshc.goonersapp.core.domain.repository.SeasonRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetSeasonListByTeamUseCase @Inject constructor(
+    private val seasonRepository: SeasonRepository
+) {
+    operator fun invoke(
+        teamId: Int
+    ): Flow<DataResult<List<Season>>> = seasonRepository.getSeasonListByTeam(teamId)
+}

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakeSeasonDataSource.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/fake/FakeSeasonDataSource.kt
@@ -1,0 +1,68 @@
+package com.eshc.goonersapp.core.network.fake
+
+import com.eshc.goonersapp.core.network.SeasonNetworkDataSource
+import com.eshc.goonersapp.core.network.model.NetworkResult
+import com.eshc.goonersapp.core.network.model.season.RemoteLeague
+import com.eshc.goonersapp.core.network.model.season.RemoteRank
+import com.eshc.goonersapp.core.network.model.season.RemoteSeason
+import javax.inject.Inject
+
+/**
+ * Created By KanuKim97
+ *
+ * [FakeSeasonDataSource]
+ *  - fakeSeasonDataSource used in data Layer Test and network Layer Unit Test
+ */
+class FakeSeasonDataSource @Inject constructor(): SeasonNetworkDataSource {
+    override suspend fun getSeasonListByTeam(teamId: Int): NetworkResult<List<RemoteSeason>> {
+        return if (teamId == 19) {
+            NetworkResult.Success(
+                listOf(
+                    RemoteSeason(
+                        seasonId = 21366,
+                        season = "2023/2024"
+                    ),
+                    RemoteSeason(
+                        seasonId = 21365,
+                        season = "2022/2023"
+                    )
+                )
+            )
+        } else {
+            NetworkResult.Error(code = 404, message = "Not Found")
+        }
+    }
+
+    override suspend fun getLeagueListAsCurrentSeasonByTeam(
+        teamId: Int
+    ): NetworkResult<List<RemoteLeague>> {
+        return if (teamId == 19) {
+            NetworkResult.Success(
+                listOf(
+                    RemoteLeague(
+                        leagueId = 1,
+                        leagueName = "Premier League",
+                        shortCode = "PL",
+                        leagueImageUrl = "",
+                        seasonId = 21366,
+                        season = "2023/2024",
+                        teamId = teamId
+                    )
+                )
+            )
+        } else {
+            NetworkResult.Error(code = 404, message = "Not Found")
+        }
+    }
+
+    override suspend fun getPreviewRankListByTeamAndSeason(
+        teamId: Int,
+        seasonId: Int,
+    ): NetworkResult<List<RemoteRank>> {
+        return if (teamId == 19 && seasonId < 21367) {
+            NetworkResult.Success(listOf())
+        } else {
+            NetworkResult.Error(404, "Not Found")
+        }
+    }
+}

--- a/core/network/src/main/java/com/eshc/goonersapp/core/network/remote/SeasonNetworkDataSourceImpl.kt
+++ b/core/network/src/main/java/com/eshc/goonersapp/core/network/remote/SeasonNetworkDataSourceImpl.kt
@@ -1,12 +1,9 @@
 package com.eshc.goonersapp.core.network.remote
 
-import com.eshc.goonersapp.core.network.PlayerNetworkDataSource
 import com.eshc.goonersapp.core.network.SeasonNetworkDataSource
-import com.eshc.goonersapp.core.network.api.PlayerNetworkService
 import com.eshc.goonersapp.core.network.api.SeasonNetworkService
 import com.eshc.goonersapp.core.network.model.NetworkResult
 import com.eshc.goonersapp.core.network.model.handleApi
-import com.eshc.goonersapp.core.network.model.player.RemotePlayer
 import com.eshc.goonersapp.core.network.model.season.RemoteLeague
 import com.eshc.goonersapp.core.network.model.season.RemoteRank
 import com.eshc.goonersapp.core.network.model.season.RemoteSeason

--- a/core/network/src/test/java/com/eshc/goonersapp/core/network/FakeSeasonDataSourceTest.kt
+++ b/core/network/src/test/java/com/eshc/goonersapp/core/network/FakeSeasonDataSourceTest.kt
@@ -1,0 +1,132 @@
+package com.eshc.goonersapp.core.network
+
+import com.eshc.goonersapp.core.network.fake.FakeSeasonDataSource
+import com.eshc.goonersapp.core.network.model.NetworkResult
+import com.eshc.goonersapp.core.network.model.season.RemoteRank
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Created By KanuKim97
+ *
+ * [FakeSeasonDataSourceTest]
+ *  - [FakeSeasonDataSource] test codes
+ */
+class FakeSeasonDataSourceTest {
+    private lateinit var fakeSeasonDataSource: FakeSeasonDataSource
+
+    @Before
+    fun setUp() {
+        fakeSeasonDataSource = FakeSeasonDataSource()
+    }
+
+    @Test
+    fun fake_get_season_list_by_team_as_success() = runBlocking {
+        when (val result = fakeSeasonDataSource.getSeasonListByTeam(19)) {
+            is NetworkResult.Success -> {
+                assertEquals(
+                    "2023/2024",
+                    result.data.first().season
+                )
+            }
+            is NetworkResult.Error -> {
+                fail("Test should not be reached here, excepted Network Result.Success")
+            }
+            is NetworkResult.Exception -> {
+                fail("Test should not be reached here, excepted Network Result.Success")
+            }
+        }
+    }
+
+    @Test
+    fun fake_get_season_list_by_team_as_error() = runBlocking {
+        when (val result = fakeSeasonDataSource.getSeasonListByTeam(20)) {
+            is NetworkResult.Error -> {
+                assertEquals(404, result.code)
+            }
+            is NetworkResult.Success -> {
+                fail("Test should not be reached here, excepted Network Result.Error")
+            }
+            is NetworkResult.Exception -> {
+                fail("Test should not be reached here, excepted Network Result.Error")
+            }
+        }
+    }
+
+    @Test
+    fun fake_get_league_list_as_current_season_by_team_as_success() = runBlocking {
+        when (val result = fakeSeasonDataSource.getLeagueListAsCurrentSeasonByTeam(19)) {
+            is NetworkResult.Success -> {
+                assertEquals(
+                    21366,
+                    result.data.first().seasonId
+                )
+            }
+            is NetworkResult.Error -> {
+                fail("Test should not be reached here, excepted Network Result.Success")
+            }
+            is NetworkResult.Exception -> {
+                fail("Test should not be reached here, excepted Network Result.Success")
+            }
+        }
+    }
+
+    @Test
+    fun fake_get_league_list_as_current_season_by_team_as_error() = runBlocking {
+        when (val result = fakeSeasonDataSource.getLeagueListAsCurrentSeasonByTeam(20)) {
+            is NetworkResult.Error -> {
+                assertEquals(404, result.code)
+            }
+            is NetworkResult.Success -> {
+                fail("Test should not be reached here, excepted Network Result.Error")
+            }
+            is NetworkResult.Exception -> {
+                fail("Test should not be reached here, excepted Network Result.Error")
+            }
+        }
+    }
+
+    @Test
+    fun fake_get_preview_rank_list_by_team_and_season_as_success() = runBlocking {
+        val result = fakeSeasonDataSource.getPreviewRankListByTeamAndSeason(
+            teamId = 19,
+            seasonId = 21366
+        )
+
+        when (result) {
+            is NetworkResult.Success -> {
+                assertEquals(listOf<RemoteRank>(), result.data)
+            }
+            is NetworkResult.Error -> {
+                fail("Test should not be reached here, excepted Network Result.Success")
+            }
+            is NetworkResult.Exception -> {
+                fail("Test should not be reached here, excepted Network Result.Success")
+            }
+        }
+    }
+
+
+    @Test
+    fun fake_get_preview_rank_list_by_team_and_season_as_error() = runBlocking {
+        val result = fakeSeasonDataSource.getPreviewRankListByTeamAndSeason(
+            teamId = 20,
+            seasonId = 21366
+        )
+
+        when (result) {
+            is NetworkResult.Error -> {
+                assertEquals(404, result.code)
+            }
+            is NetworkResult.Success -> {
+                fail("Test should not be reached here, excepted Network Result.Error")
+            }
+            is NetworkResult.Exception -> {
+                fail("Test should not be reached here, excepted Network Result.Error")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description 
Season과 관련된 API의 Repository와 UseCase를 추가했습니다.

### Content
 1. FakeSeasonRepositoryImpl 과 FakeSeasonRepositoryImplTest가 추가되었습니다.
 2. SeasonRepository와 SeasomRepositoryImpl이 추가되었습니다,
 3. 이에따른 도메인 모델들이 `Rank, Season, League` 추가되었습니다.
 4. UseCases들이 추가되었습니다.